### PR TITLE
CDAP-14932. Salesforce Batch Source fix ClassNotFoundException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <antlr.version>4.7.2</antlr.version>
     <mockito.version>1.10.19</mockito.version>
     <commons.csv.version>1.6</commons.csv.version>
+    <jackson.version>1.9.13</jackson.version>
   </properties>
 
   <dependencies>
@@ -205,6 +206,16 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <version>${commons.csv.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-core-asl</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>${jackson.version}</version>
     </dependency>
 
 


### PR DESCRIPTION
With #6  we broke the Salesforce Batch plugin. Even though the integration tests were successful (and they were the one I tested before uploading code). I didn't test the actual plugin. And it started to fail due to a very implicit dependency issue. 

`java.lang.ClassNotFoundException: org.codehaus.jackson.ObjectCodec
    at java.net.URLClassLoader.findClass(URLClassLoader.java:382) ~[na:1.8.0_202-ea]
    at co.cask.cdap.common.lang.InterceptableClassLoader.findClass(InterceptableClassLoader.java:44) ~[na:na]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[na:1.8.0_202-ea]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[na:1.8.0_202-ea]
    at co.cask.hydrator.salesforce.plugin.source.batch.SalesforceInputFormat.getSplits(SalesforceInputFormat.java:55) ~[na:na]
    at co.cask.cdap.internal.app.runtime.batch.dataset.input.MultiInputFormat.getSplits(MultiInputFormat.java:72) ~[na:na]
    at org.apache.hadoop.mapreduce.JobSubmitter.writeNewSplits(JobSubmitter.java:303) ~[org.apache.hadoop.hadoop-mapreduce-client-core-2.8.0.jar:na]
    at org.apache.hadoop.mapreduce.JobSubmitter.writeSplits(JobSubmitter.java:320) ~[org.apache.hadoop.hadoop-mapreduce-client-core-2.8.0.jar:na]
    at org.apache.hadoop.mapreduce.JobSubmitter.submitJobInternal(JobSubmitter.java:198) ~[org.apache.hadoop.hadoop-mapreduce-client-core-2.8.0.jar:na]
    at org.apache.hadoop.mapreduce.Job$11.run(Job.java:1341) ~[org.apache.hadoop.hadoop-mapreduce-client-core-2.8.0.jar:na]
    at org.apache.hadoop.mapreduce.Job$11.run(Job.java:1338) ~[org.apache.hadoop.hadoop-mapreduce-client-core-2.8.0.jar:na]
    at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_202-ea]
    at javax.security.auth.Subject.doAs(Subject.java:422) ~[na:1.8.0_202-ea]
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1807) ~[org.apache.hadoop.hadoop-common-2.8.0.jar:na]
    at org.apache.hadoop.mapreduce.Job.submit(Job.java:1338) ~[org.apache.hadoop.hadoop-mapreduce-client-core-2.8.0.jar:na]
    at co.cask.ccaused absence dap.internal.app.runtime.batch.MapReduceRuntimeService.startUp(MapReduceRuntimeService.java:355) ~[na:na]
    at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47) ~[com.google.guava.guava-13.0.1.jar:na]
    at co.cask.cdap.internal.app.runtime.batch.MapReduceRuntimeService$2$1.run(MapReduceRuntimeService.java:450) [na:na]
    at java.lang.Thread.run(Thread.java:748) [na:1.8.0_202-ea]`

**Explanation of issue:**
Salesforce library rellocates jackson libs:
 https://github.com/forcedotcom/wsc/blob/1fb9519e3117ca5fd791fd7063829dbd7281511e/pom.xml#L136

This would cause cdap class loader looking for jackson classes to fail. But since hadoop libraries also provide jackson (checked via mvn tree) this worked.

So when in #6 I have changed hadoop libraries scope to "provided". This removed jaskson library from jar. And so the failure started happening.

There are two ways of fixing this:
- remove provided tag from hadoop libs
- add jackson library manually.

Second is obviously better, since removing provided scope from hadoop libs, would mean that with salesforce plugin, we will also package all the Hadoop.