### PR TITLE
CDAP-15200: Wide object query support

### DIFF
--- a/docs/SalesforceBulk-batchsource.md
+++ b/docs/SalesforceBulk-batchsource.md
@@ -80,16 +80,18 @@ Send to error, Stop on error.
 **Schema:** The schema of output objects.
 The Salesforce types will be automacitally mapped to schema types as shown below:
 
-    +-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+
-    | Schema type |                                                                                  Salesforce type                                                                                   |    Notes     |
-    +-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+
-    | bool        | _bool                                                                                                                                                                              |              |
-    | int         | _int                                                                                                                                                                               |              |
-    | long        | _long                                                                                                                                                                              |              |
-    | double      | _double, currency, percent                                                                                                                                                         |              |
-    | date        | date                                                                                                                                                                               |              |
-    | timestamp   | datetime                                                                                                                                                                           | Milliseconds |
-    | time        | time                                                                                                                                                                               | Milliseconds |
-    | string      | picklist, multipicklist, combobox, reference, base64, textarea, phone, id, url, email, encryptedstring, datacategorygroupreference, location, address, anyType, json, complexvalue |              |
-    +-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+
-
+    +-------------+----------------------------------------------------------------------------+--------------+
+    | Schema type |                              Salesforce type                               |    Notes     |
+    +-------------+----------------------------------------------------------------------------+--------------+
+    | bool        | _bool                                                                      |              |
+    | int         | _int                                                                       |              |
+    | long        | _long                                                                      |              |
+    | double      | _double, currency, percent                                                 |              |
+    | date        | date                                                                       |              |
+    | timestamp   | datetime                                                                   | Milliseconds |
+    | time        | time                                                                       | Milliseconds |
+    | string      | picklist, multipicklist, combobox, reference, base64,                      |              |
+    |             | textarea, phone, id, url, email, encryptedstring,                          |              |
+    |             | datacategorygroupreference, location, address, anyType, json, complexvalue |              |
+    +-------------+----------------------------------------------------------------------------+--------------+
+    

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <jackson.version>1.9.13</jackson.version>
     <json.version>20180813</json.version>
     <awaitility.version>3.1.6</awaitility.version>
+    <commons-logging.version>1.2</commons-logging.version>
   </properties>
 
   <dependencies>
@@ -231,6 +232,13 @@
       <version>${json.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
+    </dependency>
+
+    <!-- Salesforce runtime dependencies to avoid NoClassDefFoundError -->
+    <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-core-asl</artifactId>
       <version>${jackson.version}</version>
@@ -241,9 +249,9 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>${awaitility.version}</version>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${commons-logging.version}</version>
     </dependency>
 
 

--- a/src/main/antlr4/soql/SOQL.g4
+++ b/src/main/antlr4/soql/SOQL.g4
@@ -210,22 +210,24 @@ IDENTIFIER          : LETTER LETTER_OR_DIGIT* ;
  * Parser Rules
  */
 
-statement           : SELECT fieldList
-                      FROM objectList
+statement           : SELECT fieldList fromStatement
+                      EOF
+                    ;
+
+fromStatement       : FROM objectList
                       (USING SCOPE filterScope)?
                       (WHERE conditionExpressions)?
                       (WITH ((DATA CATEGORY filteringExpression) | fieldExpression) )?
                       (GROUP BY (fieldGroupByList
                                 | ROLLUP '(' fieldSubtotalGroupByList ')'
                                 | CUBE '(' fieldSubtotalGroupByList ')' )
-                       (HAVING havingConditionExpression)? )?
+                      (HAVING havingConditionExpression)? )?
                       (ORDER BY fieldOrderByList)?
                       (LIMIT numberOfRowsToReturn)?
                       (OFFSET numberOfRowsToSkip)?
                       (FOR forClause)?
                       (UPDATE updateClause)?
-                      EOF
-                    ;
+                      ;
 
 fieldList           : '*' # starElement
                     | fieldElement (',' fieldElement)* # fieldElements

--- a/src/main/java/co/cask/hydrator/salesforce/SObjectDescriptor.java
+++ b/src/main/java/co/cask/hydrator/salesforce/SObjectDescriptor.java
@@ -158,7 +158,7 @@ public class SObjectDescriptor {
       if (hasParents()) {
         List<String> nameParts = new ArrayList<>(parents);
         nameParts.add(name);
-        return String.join(".", nameParts);
+        return String.join(SalesforceConstants.REFERENCE_NAME_DELIMITER, nameParts);
       }
       return name;
     }

--- a/src/main/java/co/cask/hydrator/salesforce/SalesforceConstants.java
+++ b/src/main/java/co/cask/hydrator/salesforce/SalesforceConstants.java
@@ -21,6 +21,7 @@ package co.cask.hydrator.salesforce;
 public class SalesforceConstants {
 
   public static final String API_VERSION = "45.0";
+  public static final String REFERENCE_NAME_DELIMITER = ".";
 
   public static final String PROPERTY_CLIENT_ID = "clientId";
   public static final String PROPERTY_CLIENT_SECRET = "clientSecret";
@@ -34,4 +35,7 @@ public class SalesforceConstants {
   public static final String CONFIG_USERNAME = "mapred.salesforce.user";
   public static final String CONFIG_CLIENT_SECRET = "mapred.salesforce.client.secret";
   public static final String CONFIG_LOGIN_URL = "mapred.salesforce.login.url";
+
+  public static final int INTERVAL_FILTER_MIN_VALUE = 0;
+  public static final int SOQL_MAX_LENGTH = 20000;
 }

--- a/src/main/java/co/cask/hydrator/salesforce/parser/SalesforceQueryParser.java
+++ b/src/main/java/co/cask/hydrator/salesforce/parser/SalesforceQueryParser.java
@@ -51,6 +51,18 @@ public class SalesforceQueryParser {
     getObjectDescriptorFromQuery(query);
   }
 
+  /**
+   * Returns part of SOQL query after select statement.
+   *
+   * @param query SOQL query
+   * @return from statement
+   */
+  public static String getFromStatement(String query) {
+    SOQLParser parser = initParser(query);
+    SalesforceQueryVisitor.FromStatementVisitor visitor = new SalesforceQueryVisitor.FromStatementVisitor();
+    return visitor.visit(parser.statement());
+  }
+
   private static SOQLParser initParser(String query) {
     SOQLLexer lexer = new SOQLLexer(CharStreams.fromString(query));
     lexer.removeErrorListeners();

--- a/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package co.cask.hydrator.salesforce.plugin.source.batch;
 
 import co.cask.cdap.api.annotation.Description;
@@ -21,6 +20,7 @@ import co.cask.cdap.api.annotation.Macro;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.etl.api.validation.InvalidConfigPropertyException;
 import co.cask.hydrator.salesforce.SObjectDescriptor;
+import co.cask.hydrator.salesforce.SalesforceConstants;
 import co.cask.hydrator.salesforce.SalesforceQueryUtil;
 import co.cask.hydrator.salesforce.parser.SOQLParsingException;
 import co.cask.hydrator.salesforce.parser.SalesforceQueryParser;
@@ -96,10 +96,8 @@ public class SalesforceSourceConfig extends BaseSalesforceConfig {
   }
 
   public String getQuery() {
-    if (isSoqlQuery()) {
-      return query;
-    }
-    return getSObjectQuery();
+    String soql = isSoqlQuery() ? query : getSObjectQuery();
+    return Objects.requireNonNull(soql).trim();
   }
 
   @Nullable
@@ -151,10 +149,10 @@ public class SalesforceSourceConfig extends BaseSalesforceConfig {
   }
 
   private void validateSObjectFilter(String propertyName, int propertyValue) {
-    if (!containsMacro(propertyName) && propertyValue < SalesforceQueryUtil.INTERVAL_FILTER_MIN_VALUE) {
+    if (!containsMacro(propertyName) && propertyValue < SalesforceConstants.INTERVAL_FILTER_MIN_VALUE) {
       throw new InvalidConfigPropertyException(
         String.format("Invalid SObject '%s' value: '%d'. Value must be '%d' or greater", propertyName, propertyValue,
-                      SalesforceQueryUtil.INTERVAL_FILTER_MIN_VALUE), propertyName);
+                      SalesforceConstants.INTERVAL_FILTER_MIN_VALUE), propertyName);
     }
   }
 

--- a/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceWideRecordReader.java
+++ b/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceWideRecordReader.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.hydrator.salesforce.plugin.source.batch;
+
+import co.cask.hydrator.salesforce.SObjectDescriptor;
+import co.cask.hydrator.salesforce.SalesforceConnectionUtil;
+import co.cask.hydrator.salesforce.authenticator.AuthenticatorCredentials;
+import co.cask.hydrator.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.sforce.soap.partner.PartnerConnection;
+import com.sforce.soap.partner.sobject.SObject;
+import com.sforce.ws.ConnectionException;
+import com.sforce.ws.bind.XmlObject;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.ObjectWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * RecordReader implementation for wide SOQL queries. Reads a single Salesforce batch of SObject Id's from bulk job
+ * provided in InputSplit, creates subpartitions and makes parallel SOAP calls to retrieve all values.
+ */
+public class SalesforceWideRecordReader extends SalesforceRecordReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SalesforceWideRecordReader.class);
+  private static final ObjectWriter JSON_WRITER = new ObjectMapper().writer();
+
+  private List<Map<String, String>> results;
+  private Map<String, String> value;
+  private int index;
+
+  @Override
+  public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException,
+    InterruptedException {
+    List<Map<String, String>> fetchedIdList = fetchBulkQueryIds(inputSplit, taskAttemptContext);
+    LOG.debug("Number of records received from batch job for wide object: '{}'", fetchedIdList.size());
+
+    Configuration conf = taskAttemptContext.getConfiguration();
+    try {
+      AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
+      PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
+
+      String query = conf.get(SalesforceSourceConstants.CONFIG_QUERY);
+      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
+      List<String> fieldsNames = sObjectDescriptor.getFieldsNames();
+
+      String fields = String.join(",", fieldsNames);
+      String sObjectName = sObjectDescriptor.getName();
+
+      List<List<Map<String, String>>> partitions =
+        Lists.partition(fetchedIdList, SalesforceSourceConstants.WIDE_QUERY_MAX_BATCH_COUNT);
+      LOG.debug("Number of partitions to be fetched for wide object: '{}'", partitions.size());
+
+      results = partitions.parallelStream()
+        .map(this::getSObjectIds)
+        .map(sObjectIds -> fetchPartition(partnerConnection, fields, sObjectName, sObjectIds))
+        .flatMap(Arrays::stream)
+        .map(sObject -> transformToMap(sObject, sObjectDescriptor.getFields()))
+        .collect(Collectors.toList());
+    } catch (ConnectionException e) {
+      throw new RuntimeException("Cannot create Salesforce SOAP connection", e);
+    }
+  }
+
+  @Override
+  public boolean nextKeyValue() {
+    if (results.size() == index) {
+      return false;
+    }
+    value = results.get(index++);
+    return true;
+  }
+
+  @Override
+  public Map<String, String> getCurrentValue() {
+    return value;
+  }
+
+  @Override
+  public float getProgress() {
+    return results == null || results.isEmpty() ? 0.0f : (float) index / results.size();
+  }
+
+  @VisibleForTesting
+  Map<String, String> transformToMap(SObject sObject, List<SObjectDescriptor.FieldDescriptor> fieldsNames) {
+    Map<String, String> result = new HashMap<>(fieldsNames.size());
+    for (SObjectDescriptor.FieldDescriptor fieldDescriptor : fieldsNames) {
+      Object fieldValue = extractValue(sObject, fieldDescriptor.getName(), fieldDescriptor.getParents());
+
+      result.put(fieldDescriptor.getFullName(), fieldValue == null ? null : String.valueOf(fieldValue));
+    }
+    return result;
+  }
+
+  /**
+   * Fetches single entry map (Id -> SObjectId_value) values received from Bulk API.
+   *
+   * @param inputSplit         specifies batch details
+   * @param taskAttemptContext task context
+   * @return list of single entry Map
+   * @throws IOException          can be due error during reading query
+   * @throws InterruptedException interrupted sleep while waiting for batch results
+   */
+  private List<Map<String, String>> fetchBulkQueryIds(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+    throws IOException, InterruptedException {
+    super.initialize(inputSplit, taskAttemptContext);
+    List<Map<String, String>> fetchedIdList = new ArrayList<>();
+    while (super.nextKeyValue()) {
+      fetchedIdList.add(super.getCurrentValue());
+    }
+    return fetchedIdList;
+  }
+
+  /**
+   * Transforms list of single entry map to array of SObject ids.
+   * <p/>
+   * Example:
+   * <ul>
+   *  <li>Expected list of map format: `List(Map(Id -> SObject_id1), Map(Id -> SObject_id2), ...)`</li>
+   *  <li>Result array: `[SObject_id1, SObject_id2, ...]`</li>
+   * </ul>
+   * @param subIds list of single entry Map
+   * @return array of SObject ids
+   */
+  private String[] getSObjectIds(List<Map<String, String>> subIds) {
+    return subIds.stream()
+      .map(Map::values)
+      .flatMap(Collection::stream)
+      .toArray(String[]::new);
+  }
+
+  /**
+   * Fetches wide object records through SOAP API.
+   *
+   * @param partnerConnection SOAP connection
+   * @param fields            SObject fields to be fetched
+   * @param sObjectName       SObject name
+   * @param sObjectIds        SObject ids to be fetched
+   * @return fetched SObject array
+   */
+  private SObject[] fetchPartition(PartnerConnection partnerConnection, String fields, String sObjectName,
+                                   String[] sObjectIds) {
+    try {
+      return partnerConnection.retrieve(fields, sObjectName, sObjectIds);
+    } catch (ConnectionException e) {
+      LOG.trace("Fetched SObject name: '{}', fields: '{}', Ids: '{}'", sObjectName, fields,
+                String.join(",", sObjectIds));
+      throw new RuntimeException(String.format("Cannot retrieve data for SObject '%s'", sObjectName), e);
+    }
+  }
+
+  /**
+   * Extracts value from XmlObject field. Reference type fields extracted recursively.
+   * <p/>
+   * Example: `SELECT Id, Name, Campaign.Id FROM Opportunity LIMIT 1`
+   * <p/>
+   * Response:
+   * <pre>
+   * XmlObject{name=Opportunity, value=null,
+   *   children=[
+   *     XmlObject{name=Id, value=oid-1, children=[]},
+   *     XmlObject{name=Name, value=value1, children=[]},
+   *     XmlObject{name=Campaign, value=null, children=[XmlObject{name=Id, value=cid-1, children=[]}]}
+   *   ]
+   * }
+   * </pre>
+   * <ul>
+   *  <li>Extract simple field  `Id` from SObject Opportunity:
+   *  name=`Id`, children=`empty List()` -> `oid-1`</li>
+   *  <li>Extract simple field  `Name` from SObject Opportunity:
+   *  name=`Name`, children=`empty List()` -> `value1`</li>
+   *  <li>Extract reference field  `Campaign.Id` from SObject Opportunity:
+   *  name=`Id`, children=`List(Campaign)` -> `cid-1`</li>
+   * </ul>
+   *
+   * @param xmlObject field value holder
+   * @param name      field name
+   * @param children  field's children names
+   * @return field value
+   */
+  private Object extractValue(XmlObject xmlObject, String name, List<String> children) {
+    if (children.isEmpty()) {
+      Object value = xmlObject.getField(name);
+      if (value instanceof XmlObject) {
+        value = extractCompoundValue(name, (XmlObject) value);
+      }
+      return value;
+    }
+    String childName = children.get(0);
+    XmlObject child = xmlObject.getChild(childName);
+    if (child == null) {
+      throw new IllegalStateException(
+        String.format("SObject reference field with name '%s' not found in parent '%s'",
+                      childName, xmlObject.getName().getLocalPart()));
+    }
+    // remove higher level child from list and check remaining
+    return extractValue(child, name, children.subList(1, children.size()));
+  }
+
+  /**
+   * Extracts compound values and retrieves value in JSON format.
+   *
+   * @param name field name
+   * @param compoundField compound field value holder
+   * @return compound value
+   */
+  private String extractCompoundValue(String name, XmlObject compoundField) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    for (Iterator<XmlObject> it = compoundField.getChildren(); it.hasNext(); ) {
+      XmlObject compoundChild = it.next();
+      map.put(compoundChild.getName().getLocalPart(), compoundChild.getValue());
+    }
+    try {
+      return JSON_WRITER.writeValueAsString(map);
+    } catch (IOException e) {
+      throw new RuntimeException(
+        String.format("Cannot transform compound value for field '%s'. Compound value '%s'", name, compoundField), e);
+    }
+  }
+}

--- a/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package co.cask.hydrator.salesforce.plugin.source.batch.util;
 
 /**
@@ -31,4 +30,5 @@ public class SalesforceSourceConstants {
 
   public static final int DURATION_DEFAULT = 0;
   public static final int OFFSET_DEFAULT = 0;
+  public static final int WIDE_QUERY_MAX_BATCH_COUNT = 2000;
 }

--- a/src/test/java/co/cask/hydrator/salesforce/etl/SObjectBuilder.java
+++ b/src/test/java/co/cask/hydrator/salesforce/etl/SObjectBuilder.java
@@ -13,13 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package co.cask.hydrator.salesforce.etl;
 
 import com.sforce.soap.partner.sobject.SObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.namespace.QName;
 
 /**
  * Builder class for {@link com.sforce.soap.partner.sobject.SObject}
@@ -44,6 +44,7 @@ public class SObjectBuilder {
     }
     SObject sobject = new SObject();
     sobject.setType(type);
+    sobject.setName(QName.valueOf(type));
 
     for (Map.Entry<String, Object> entry : fields.entrySet()) {
       sobject.setField(entry.getKey(), entry.getValue());

--- a/src/test/java/co/cask/hydrator/salesforce/parser/SalesforceQueryParserTest.java
+++ b/src/test/java/co/cask/hydrator/salesforce/parser/SalesforceQueryParserTest.java
@@ -120,4 +120,13 @@ public class SalesforceQueryParserTest {
       });
   }
 
+  @Test
+  public void testFromStatement() {
+    String fromStatement = "FROM Contact WHERE Account.Industry = 'media'";
+    String query = "SELECT Id, Name, Account.Name " + fromStatement;
+
+    String result = SalesforceQueryParser.getFromStatement(query);
+    Assert.assertEquals(fromStatement, result);
+  }
+
 }

--- a/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceRecordReaderTest.java
+++ b/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceRecordReaderTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package co.cask.hydrator.salesforce.plugin.source.batch;
 
 import co.cask.cdap.api.data.format.StructuredRecord;
@@ -127,27 +126,6 @@ public class SalesforceRecordReaderTest {
       .build();
 
     assertRecordReaderOutputRecords(csvString, schema, expectedRecords);
-  }
-
-  @Test
-  public void testKeysAndValuesDifferentNumber() throws Exception {
-    String csvString = "\"key1\",\"key2\",\"key3\"\n" +
-      "\"value1\",\"value2\",\"value3\",\"value4\"";
-
-    Schema schema = Schema.recordOf("output",
-                                    Schema.Field.of("key1", Schema.of(Schema.Type.STRING)),
-                                    Schema.Field.of("key2", Schema.of(Schema.Type.STRING)),
-                                    Schema.Field.of("key3", Schema.of(Schema.Type.STRING))
-    );
-
-    List<Map<String, Object>> expectedRecords = new ImmutableList.Builder<Map<String, Object>>().build();
-
-    try {
-      assertRecordReaderOutputRecords(csvString, schema, expectedRecords);
-      Assert.fail("Expected to throw exception due to not different number of arguments");
-    } catch (IllegalArgumentException ex) {
-      Assert.assertTrue(ex.getMessage().contains("is not consistent to a csv mapping"));
-    }
   }
 
   @Test
@@ -272,7 +250,7 @@ public class SalesforceRecordReaderTest {
     ArgumentCaptor<StructuredRecord> argument = ArgumentCaptor.forClass(StructuredRecord.class);
 
     while (rr.nextKeyValue()) {
-      KeyValue<NullWritable, CSVRecord> keyValue = new KeyValue<>(null, rr.getCurrentValue());
+      KeyValue<NullWritable, Map<String, String>> keyValue = new KeyValue<>(null, rr.getCurrentValue());
       salesforceBatchSource.transform(keyValue, emitter);
     }
 

--- a/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceWideRecordReaderTest.java
+++ b/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceWideRecordReaderTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.hydrator.salesforce.plugin.source.batch;
+
+import co.cask.hydrator.salesforce.SObjectDescriptor;
+import co.cask.hydrator.salesforce.SalesforceConstants;
+import co.cask.hydrator.salesforce.etl.SObjectBuilder;
+import com.sforce.soap.partner.Address;
+import com.sforce.soap.partner.sobject.SObject;
+import com.sforce.ws.bind.XmlObjectWrapper;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.xml.namespace.QName;
+
+public class SalesforceWideRecordReaderTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testTransformToMap() {
+    SalesforceWideRecordReader recordReader = new SalesforceWideRecordReader();
+    SObject campaign = new SObjectBuilder()
+      .setType("Campaign")
+      .put("Id", "testCampaignId")
+      .put("Name", "TestCampaign-1")
+      .build();
+
+    SObject opportunity = new SObjectBuilder()
+      .setType("Opportunity")
+      .put("Id", "testOpportunityId")
+      .put("Name", "testOpportunity-1")
+      .put("Amount", "25000")
+      .put(campaign.getType(), campaign)
+      .build();
+
+    List<SObjectDescriptor.FieldDescriptor> fieldDescriptors =
+      getFieldDescriptors("Name", "Id", "Campaign.Name", "Campaign.Id");
+    Map<String, String> resultMap = recordReader.transformToMap(opportunity, fieldDescriptors);
+
+    Assert.assertNotNull(resultMap);
+    Assert.assertEquals(fieldDescriptors.size(), resultMap.size());
+
+    Assert.assertEquals(opportunity.getField("Name"), resultMap.get("Name"));
+    Assert.assertEquals(opportunity.getField("Id"), resultMap.get("Id"));
+    Assert.assertEquals(campaign.getField("Name"), resultMap.get("Campaign.Name"));
+    Assert.assertEquals(campaign.getField("Id"), resultMap.get("Campaign.Id"));
+  }
+
+  @Test
+  public void testTransformToMapCompoundField() throws JSONException {
+    SalesforceWideRecordReader recordReader = new SalesforceWideRecordReader();
+
+    Address address = new Address();
+    address.setCity("New York");
+    address.setCountry("US");
+    address.setPostalCode("10001");
+    address.setState("NY");
+
+    XmlObjectWrapper compoundFieldBillingAddress = new XmlObjectWrapper(address);
+    compoundFieldBillingAddress.setName(QName.valueOf("BillingAddress"));
+
+    SObject opportunity = new SObjectBuilder()
+      .setType("Opportunity")
+      .put("Id", "testOpportunityId")
+      .put("Name", "testOpportunity-1")
+      .put("Amount", "25000")
+      .put(compoundFieldBillingAddress.getName().getLocalPart(), compoundFieldBillingAddress)
+      .build();
+
+    List<SObjectDescriptor.FieldDescriptor> fieldDescriptors =
+      getFieldDescriptors("Id", "BillingAddress");
+    Map<String, String> resultMap = recordReader.transformToMap(opportunity, fieldDescriptors);
+
+    Assert.assertNotNull(resultMap);
+    Assert.assertEquals(fieldDescriptors.size(), resultMap.size());
+
+    Assert.assertEquals(opportunity.getField("Id"), resultMap.get("Id"));
+
+    String billingAddress = resultMap.get("BillingAddress");
+    Assert.assertNotNull(billingAddress);
+    // check compound field json
+    JSONObject jsonObject = new JSONObject(billingAddress);
+    Assert.assertEquals(address.getCity(), jsonObject.getString("city"));
+    Assert.assertEquals(address.getCountry(), jsonObject.getString("country"));
+    Assert.assertEquals(address.getPostalCode(), jsonObject.getString("postalCode"));
+    Assert.assertEquals(address.getState(), jsonObject.getString("state"));
+
+    Assert.assertTrue(jsonObject.isNull("street"));
+    Assert.assertTrue(jsonObject.isNull("latitude"));
+    Assert.assertTrue(jsonObject.isNull("longitude"));
+  }
+
+
+  @Test
+  public void testTransformToMapIncorrectReferenceField() {
+    SalesforceWideRecordReader recordReader = new SalesforceWideRecordReader();
+    SObject opportunity = new SObjectBuilder()
+      .setType("Opportunity")
+      .put("Id", "testOpportunityId")
+      .put("Name", "testOpportunity-1")
+      .put("Amount", "25000")
+      .build();
+
+    List<SObjectDescriptor.FieldDescriptor> fieldDescriptors =
+      getFieldDescriptors("Name", "Id", "Campaign.Name", "Campaign.Id");
+    thrown.expect(IllegalStateException.class);
+
+    recordReader.transformToMap(opportunity, fieldDescriptors);
+  }
+
+  private List<SObjectDescriptor.FieldDescriptor> getFieldDescriptors(String... fields) {
+    return Stream.of(fields)
+      .map(name -> name.split("\\" + SalesforceConstants.REFERENCE_NAME_DELIMITER))
+      .map(Arrays::asList)
+      .map(SObjectDescriptor.FieldDescriptor::new)
+      .collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
1. Extend SOQL parser to extract FROM clause from query
2. Narrow Salesforce reference schema table for batchsource.md
3. Add wide object query support
3.1. added WideRecordReader to extend batch RecordReader logic
3.2. added SOQL length check to InputFormat to detected which RecordReader should be used
3.3. switched RecordReader value from CsvRecord to more generic Map<String, String>