### PR TITLE
CDAP-15247 Remove spark-plugins:jar:2.2.0-SNAPSHOT from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,11 +190,6 @@
       <version>${spark2.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>co.cask.hydrator</groupId>
-      <artifactId>spark-plugins</artifactId>
-      <version>${hydrator.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This dependency is broken in repo. So unless installed locally the build fails: 

[WARNING] The POM for co.cask.hydrator:spark-plugins:jar:2.2.0-SNAPSHOT is invalid, transitive dependencies (if any) will not be available: 1 problem was encountered while building the effective model for co.cask.hydrator:spark-plugins:2.2.0-SNAPSHOT
...
[ERROR] Failed to execute goal on project salesforce-plugins: Could not resolve dependencies for project co.cask.hydrator:salesforce-plugins:jar:1.0.0-SNAPSHOT: Could not find artifact co.cask.hydrator:spark-plugins:jar:2.2.0-SNAPSHOT -> [Help 1]
[ERROR]

For other streaming plugin seems like this dependency is not used as well. And we have only small class we use from it.