### PR TITLE
CDAP-15245: Use provided schema during pipeline run

### DIFF
--- a/docs/SalesforceBulk-batchsource.md
+++ b/docs/SalesforceBulk-batchsource.md
@@ -78,7 +78,7 @@ Send to error, Stop on error.
     +---------------+----------------------------------------------------------------------------------------------------+
 
 **Schema:** The schema of output objects.
-The Salesforce types will be automacitally mapped to schema types as shown below:
+The Salesforce types will be automatically mapped to schema types as shown below:
 
     +-------------+----------------------------------------------------------------------------+--------------+
     | Schema type |                              Salesforce type                               |    Notes     |
@@ -88,8 +88,8 @@ The Salesforce types will be automacitally mapped to schema types as shown below
     | long        | _long                                                                      |              |
     | double      | _double, currency, percent                                                 |              |
     | date        | date                                                                       |              |
-    | timestamp   | datetime                                                                   | Milliseconds |
-    | time        | time                                                                       | Milliseconds |
+    | timestamp   | datetime                                                                   | Microseconds |
+    | time        | time                                                                       | Microseconds |
     | string      | picklist, multipicklist, combobox, reference, base64,                      |              |
     |             | textarea, phone, id, url, email, encryptedstring,                          |              |
     |             | datacategorygroupreference, location, address, anyType, json, complexvalue |              |

--- a/docs/SalesforceStreaming-streamingsource.md
+++ b/docs/SalesforceStreaming-streamingsource.md
@@ -82,8 +82,8 @@ The Salesforce types will be automatically mapped to schema types as shown below
 | long        | _long                                                                      |              |
 | double      | _double, currency, percent                                                 |              |
 | date        | date                                                                       |              |
-| timestamp   | datetime                                                                   | Milliseconds |
-| time        | time                                                                       | Milliseconds |
+| timestamp   | datetime                                                                   | Microseconds |
+| time        | time                                                                       | Microseconds |
 | string      | picklist, multipicklist, combobox, reference, base64,                      |              |
 |             | textarea, phone, id, url, email, encryptedstring,                          |              |
 |             | datacategorygroupreference, location, address, anyType, json, complexvalue |              |

--- a/src/main/java/co/cask/hydrator/salesforce/SalesforceSchemaUtil.java
+++ b/src/main/java/co/cask/hydrator/salesforce/SalesforceSchemaUtil.java
@@ -18,17 +18,51 @@ package co.cask.hydrator.salesforce;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.hydrator.salesforce.authenticator.AuthenticatorCredentials;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.sforce.soap.partner.Field;
+import com.sforce.soap.partner.FieldType;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.ws.ConnectionException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Salesforce utils for parsing SOQL and generating schema
  */
 public class SalesforceSchemaUtil {
+
+  private static final Map<FieldType, Schema> SALESFORCE_TYPE_TO_CDAP_SCHEMA =
+    new ImmutableMap.Builder<FieldType, Schema>()
+    .put(FieldType._boolean, Schema.of(Schema.Type.BOOLEAN))
+    .put(FieldType._int, Schema.of(Schema.Type.INT))
+    .put(FieldType._long, Schema.of(Schema.Type.LONG))
+    .put(FieldType._double, Schema.of(Schema.Type.DOUBLE))
+    .put(FieldType.currency, Schema.of(Schema.Type.DOUBLE))
+    .put(FieldType.percent, Schema.of(Schema.Type.DOUBLE))
+    .put(FieldType.date, Schema.of(Schema.LogicalType.DATE))
+    .put(FieldType.datetime, Schema.of(Schema.LogicalType.TIMESTAMP_MICROS))
+    .put(FieldType.time, Schema.of(Schema.LogicalType.TIME_MICROS))
+    .put(FieldType.string, Schema.of(Schema.Type.STRING))
+    .build();
+
+  private static final Set<Schema.Type> SUPPORTED_TYPES =
+    SALESFORCE_TYPE_TO_CDAP_SCHEMA.values().stream()
+      .map(Schema::getType)
+      .collect(Collectors.collectingAndThen(Collectors.toSet(), ImmutableSet::copyOf));
+
+  private static final Set<Schema.LogicalType> SUPPORTED_LOGICAL_TYPES =
+    SALESFORCE_TYPE_TO_CDAP_SCHEMA.values().stream()
+      .map(Schema::getLogicalType)
+      .filter(Objects::nonNull)
+      .collect(Collectors.collectingAndThen(Collectors.toSet(), ImmutableSet::copyOf));
+
+  private static final Schema DEFAULT_SCHEMA = Schema.of(Schema.Type.STRING);
 
   /**
    * Connects to Salesforce and obtains description of sObjects needed to determine schema field types.
@@ -48,6 +82,70 @@ public class SalesforceSchemaUtil {
     return getSchemaWithFields(sObjectDescriptor, describeResult);
   }
 
+  /**
+   * Validates that fields from given CDAP schema are of supported schema.
+   *
+   * @param schema CDAP schema
+   */
+  public static void validateFieldSchemas(Schema schema) {
+    for (Schema.Field field : Objects.requireNonNull(schema.getFields(), "Schema must have fields")) {
+      Schema fieldSchema = field.getSchema();
+      fieldSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+      if (!SUPPORTED_TYPES.contains(fieldSchema.getType())) {
+        throw new IllegalArgumentException(
+          String.format("Field '%s' is of unsupported type '%s'", field.getName(), fieldSchema.getType()));
+      }
+
+      Schema.LogicalType logicalType = fieldSchema.getLogicalType();
+      if (logicalType != null && !SUPPORTED_LOGICAL_TYPES.contains(logicalType)) {
+        throw new IllegalArgumentException(
+          String.format("Field '%s' is of unsupported type '%s'", field.getName(), logicalType.getToken()));
+      }
+    }
+  }
+
+  /**
+   * Checks two schemas compatibility based on the following rules:
+   * <ul>
+   *   <li>Actual schema must have fields indicated in the provided schema.</li>
+   *   <li>Fields types in both schema must match.</li>
+   *   <li>If actual schema field is required, provided schema field can be required or nullable.</li>
+   *   <li>If actual schema field is nullable, provided schema field must be nullable.</li>
+   * </ul>
+   *
+   * @param actualSchema schema calculated based on Salesforce metadata information
+   * @param providedSchema schema provided in the configuration
+   */
+  public static void checkCompatibility(Schema actualSchema, Schema providedSchema) {
+    for (Schema.Field providedField : Objects.requireNonNull(providedSchema.getFields())) {
+      Schema.Field actualField = actualSchema.getField(providedField.getName());
+      if (actualField == null) {
+        throw new IllegalArgumentException(
+          String.format("Field '%s' does not exist in Salesforce", providedField.getName()));
+      }
+
+      Schema providedFieldSchema = providedField.getSchema();
+      Schema actualFieldSchema = actualField.getSchema();
+
+      boolean isActualFieldNullable = actualFieldSchema.isNullable();
+      boolean isProvidedFieldNullable = providedFieldSchema.isNullable();
+
+      actualFieldSchema = isActualFieldNullable ? actualFieldSchema.getNonNullable() : actualFieldSchema;
+      providedFieldSchema = isProvidedFieldNullable ? providedFieldSchema.getNonNullable() : providedFieldSchema;
+
+      if (!actualFieldSchema.equals(providedFieldSchema)
+        || !Objects.equals(actualFieldSchema.getLogicalType(), providedFieldSchema.getLogicalType())) {
+        throw new IllegalArgumentException(
+          String.format("Expected field '%s' to be of '%s', but it is of '%s'",
+            providedField.getName(), providedFieldSchema, actualFieldSchema));
+      }
+
+      if (isActualFieldNullable && !isProvidedFieldNullable) {
+        throw new IllegalArgumentException(String.format("Field '%s' should be nullable", providedField.getName()));
+      }
+    }
+  }
+
   @VisibleForTesting
   static Schema getSchemaWithFields(SObjectDescriptor sObjectDescriptor, SObjectsDescribeResult describeResult) {
     List<Schema.Field> schemaFields = new ArrayList<>();
@@ -59,42 +157,15 @@ public class SalesforceSchemaUtil {
         throw new IllegalArgumentException(
           String.format("Field '%s' is absent in Salesforce describe result", fieldDescriptor.getFullName()));
       }
-      Schema.Field schemaField = Schema.Field.of(fieldDescriptor.getFullName(), getCdapSchemaField(field));
+      Schema.Field schemaField = Schema.Field.of(fieldDescriptor.getFullName(), getCdapFieldSchema(field));
       schemaFields.add(schemaField);
     }
 
     return Schema.recordOf("output",  schemaFields);
   }
 
-  private static Schema getCdapSchemaField(Field field) {
-    Schema fieldSchema;
-    switch (field.getType()) {
-      case _boolean:
-        fieldSchema = Schema.of(Schema.Type.BOOLEAN);
-        break;
-      case _int:
-        fieldSchema = Schema.of(Schema.Type.INT);
-        break;
-      case _long:
-        fieldSchema = Schema.of(Schema.Type.LONG);
-        break;
-      case _double:
-      case currency:
-      case percent:
-        fieldSchema = Schema.of(Schema.Type.DOUBLE);
-        break;
-      case date:
-        fieldSchema = Schema.of(Schema.LogicalType.DATE);
-        break;
-      case datetime:
-        fieldSchema = Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS);
-        break;
-      case time:
-        fieldSchema = Schema.of(Schema.LogicalType.TIME_MILLIS);
-        break;
-      default:
-        fieldSchema = Schema.of(Schema.Type.STRING);
-    }
+  private static Schema getCdapFieldSchema(Field field) {
+    Schema fieldSchema = SALESFORCE_TYPE_TO_CDAP_SCHEMA.getOrDefault(field.getType(), DEFAULT_SCHEMA);
     return field.isNillable() ? Schema.nullableOf(fieldSchema) : fieldSchema;
   }
 

--- a/src/main/java/co/cask/hydrator/salesforce/plugin/BaseSalesforceConfig.java
+++ b/src/main/java/co/cask/hydrator/salesforce/plugin/BaseSalesforceConfig.java
@@ -111,12 +111,25 @@ public class BaseSalesforceConfig extends ReferencePluginConfig {
     return SalesforceConnectionUtil.getAuthenticatorCredentials(username, password, clientId, clientSecret, loginUrl);
   }
 
-  private void validateConnection() {
+  /**
+   * Checks if current config does not contain macro for properties which are used
+   * to establish connection to Salesforce.
+   *
+   * @return true if none of the connection properties contains macro, false otherwise
+   */
+  public boolean canAttemptToEstablishConnection() {
     if (containsMacro(SalesforceConstants.PROPERTY_CLIENT_ID)
       || containsMacro(SalesforceConstants.PROPERTY_CLIENT_SECRET)
       || containsMacro(SalesforceConstants.PROPERTY_USERNAME)
       || containsMacro(SalesforceConstants.PROPERTY_PASSWORD)
       || containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL)) {
+      return false;
+    }
+    return true;
+  }
+
+  private void validateConnection() {
+    if (!canAttemptToEstablishConnection()) {
       return;
     }
 

--- a/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/co/cask/hydrator/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -20,15 +20,18 @@ package co.cask.hydrator.salesforce.plugin.source.batch.util;
  */
 public class SalesforceSourceConstants {
 
-  public static final String PROPERTY_QUERY = "query";
-  public static final String PROPERTY_SOBJECT_NAME = "sObjectName";
   public static final String PROPERTY_DATETIME_FILTER = "datetimeFilter";
   public static final String PROPERTY_DURATION = "duration";
   public static final String PROPERTY_OFFSET = "offset";
+  public static final String PROPERTY_SCHEMA = "schema";
+
+  public static final String PROPERTY_QUERY = "query";
+  public static final String PROPERTY_SOBJECT_NAME = "sObjectName";
 
   public static final String CONFIG_QUERY = "mapred.salesforce.input.query";
 
   public static final int DURATION_DEFAULT = 0;
   public static final int OFFSET_DEFAULT = 0;
   public static final int WIDE_QUERY_MAX_BATCH_COUNT = 2000;
+
 }

--- a/src/test/java/co/cask/hydrator/salesforce/etl/BaseSalesforceBatchSourceETLTest.java
+++ b/src/test/java/co/cask/hydrator/salesforce/etl/BaseSalesforceBatchSourceETLTest.java
@@ -225,12 +225,17 @@ public abstract class BaseSalesforceBatchSourceETLTest extends HydratorTestBase 
   }
 
   protected List<StructuredRecord> getResultsBySObjectQuery(String sObjectName,
-                                                            String datetimeFilter) throws Exception {
+                                                            String datetimeFilter,
+                                                            String schema) throws Exception {
     ImmutableMap.Builder<String, String> propsBuilder = getBaseProperties()
       .put(SalesforceSourceConstants.PROPERTY_SOBJECT_NAME, sObjectName);
 
     if (datetimeFilter != null) {
       propsBuilder.put(SalesforceSourceConstants.PROPERTY_DATETIME_FILTER, datetimeFilter);
+    }
+
+    if (schema != null) {
+      propsBuilder.put(SalesforceSourceConstants.PROPERTY_SCHEMA, schema);
     }
 
     return getPipelineResults(propsBuilder.build());

--- a/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceRecordReaderTest.java
+++ b/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceRecordReaderTest.java
@@ -19,9 +19,9 @@ import co.cask.cdap.api.data.format.StructuredRecord;
 import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.api.dataset.lib.KeyValue;
 import co.cask.cdap.etl.api.Emitter;
+import co.cask.hydrator.salesforce.plugin.ErrorHandling;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.csv.CSVRecord;
 import org.apache.hadoop.io.NullWritable;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class SalesforceRecordReaderTest {
                                     Schema.Field.of("Id", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("IsDeleted", Schema.of(Schema.Type.BOOLEAN)),
                                     Schema.Field.of("ExpectedRevenue", Schema.of(Schema.Type.DOUBLE)),
-                                    Schema.Field.of("LastModifiedDate", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                                    Schema.Field.of("LastModifiedDate", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
                                     Schema.Field.of("CloseDate", Schema.of(Schema.LogicalType.DATE))
     );
 
@@ -57,7 +57,7 @@ public class SalesforceRecordReaderTest {
              .put("Id", "0061i000003XNcBAAW")
              .put("IsDeleted", false)
              .put("ExpectedRevenue", 1500.0)
-             .put("LastModifiedDate", 1550819001000L)
+             .put("LastModifiedDate", 1550819001000000L)
              .put("CloseDate", 17897)
              .build()
       )
@@ -65,7 +65,7 @@ public class SalesforceRecordReaderTest {
              .put("Id", "0061i000003XNcCAAW")
              .put("IsDeleted", false)
              .put("ExpectedRevenue", 112500.0)
-             .put("LastModifiedDate", 1550819001000L)
+             .put("LastModifiedDate", 1550819001000000L)
              .put("CloseDate", 17885)
              .build()
       )
@@ -73,7 +73,7 @@ public class SalesforceRecordReaderTest {
              .put("Id", "0061i000003XNcDAAW")
              .put("IsDeleted", false)
              .put("ExpectedRevenue", 220000.0)
-             .put("LastModifiedDate", 1550819001000L)
+             .put("LastModifiedDate", 1550819001000000L)
              .put("CloseDate", 17850)
              .build()
       )
@@ -94,7 +94,7 @@ public class SalesforceRecordReaderTest {
                                     Schema.Field.of("Id", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("IsDeleted\u0628\u0633\u0645", Schema.of(Schema.Type.BOOLEAN)),
                                     Schema.Field.of("ExpectedRevenue", Schema.of(Schema.Type.DOUBLE)),
-                                    Schema.Field.of("LastModifiedDate", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                                    Schema.Field.of("LastModifiedDate", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
                                     Schema.Field.of("CloseDate", Schema.of(Schema.LogicalType.DATE))
     );
 
@@ -103,7 +103,7 @@ public class SalesforceRecordReaderTest {
              .put("Id", "0061i000003XNcBAAW\u0628\u0633\u0645")
              .put("IsDeleted\u0628\u0633\u0645", false)
              .put("ExpectedRevenue", 1500.0)
-             .put("LastModifiedDate", 1550819001000L)
+             .put("LastModifiedDate", 1550819001000000L)
              .put("CloseDate", 17897)
              .build()
       )
@@ -111,7 +111,7 @@ public class SalesforceRecordReaderTest {
              .put("Id", "0061i000003XNcCAAW")
              .put("IsDeleted\u0628\u0633\u0645", false)
              .put("ExpectedRevenue", 112500.0)
-             .put("LastModifiedDate", 1550819001000L)
+             .put("LastModifiedDate", 1550819001000000L)
              .put("CloseDate", 17885)
              .build()
       )
@@ -119,7 +119,7 @@ public class SalesforceRecordReaderTest {
              .put("Id", "0061i000003XNcDAAW")
              .put("IsDeleted\u0628\u0633\u0645", false)
              .put("ExpectedRevenue", 220000.0)
-             .put("LastModifiedDate", 1550819001000L)
+             .put("LastModifiedDate", 1550819001000000L)
              .put("CloseDate", 17850)
              .build()
       )
@@ -234,7 +234,7 @@ public class SalesforceRecordReaderTest {
       .setUsername("myUsername")
       .setPassword("myPassword")
       .setLoginUrl("myLoginUrl")
-      .setErrorHandling("Stop on error")
+      .setErrorHandling(ErrorHandling.STOP.getValue())
       .setQuery("myQuery")
       .build();
 

--- a/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/co/cask/hydrator/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -32,6 +32,7 @@ public class SalesforceSourceConfigBuilder {
   private String datetimeFilter;
   private Integer duration;
   private Integer offset;
+  private String schema;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -93,8 +94,13 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
+  public SalesforceSourceConfigBuilder setSchema(String schema) {
+    this.schema = schema;
+    return this;
+  }
+
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, clientId, clientSecret, username, password, loginUrl,
-                                      errorHandling, query, sObjectName, datetimeFilter, duration, offset);
+                                      errorHandling, query, sObjectName, datetimeFilter, duration, offset, schema);
   }
 }


### PR DESCRIPTION
Currently when user provides schema it is completely ignored. This PR aims to improve such behavior.

Use case: user wants to query data by sObject instead of writing SOQL but does not need all fields.

1. User indicates sObject name.
2. User generates and imports schema using `Get Schema` button.
3. User removes some fields from the schema and runs pipeline.
4. Data will be retrieved only for the fields indicated in the schema.