### PR TITLE
CDAP-15228: Exclude compound field types from SObject query but leave individual fields

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SObjectDescriptor.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SObjectDescriptor.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Contains information about SObject, including its name and list of fields.
@@ -56,7 +57,6 @@ public class SObjectDescriptor {
       partnerConnection, Collections.singletonList(name));
     List<FieldDescriptor> fields = describeResult.getFields().stream()
       .filter(field -> !typesToSkip.contains(field.getType()))
-      .map(Field::getName)
       .map(FieldDescriptor::new)
       .collect(Collectors.toList());
 
@@ -130,11 +130,11 @@ public class SObjectDescriptor {
    */
   public static class FieldDescriptor {
 
-    private final String name;
+    private final Field field;
     private final List<String> parents;
 
-    public FieldDescriptor(String name) {
-      this.name = name;
+    public FieldDescriptor(Field field) {
+      this.field = field;
       this.parents = new ArrayList<>();
     }
 
@@ -142,11 +142,12 @@ public class SObjectDescriptor {
       Preconditions.checkState(nameParts != null && !nameParts.isEmpty(),
         "Given list of name parts must contain at least one element");
       this.parents = new ArrayList<>(nameParts);
-      this.name = parents.remove(nameParts.size() - 1);
+      this.field = new Field();
+      field.setName(parents.remove(nameParts.size() - 1));
     }
 
     public String getName() {
-      return name;
+      return field.getName();
     }
 
     /**
@@ -157,10 +158,10 @@ public class SObjectDescriptor {
     public String getFullName() {
       if (hasParents()) {
         List<String> nameParts = new ArrayList<>(parents);
-        nameParts.add(name);
+        nameParts.add(field.getName());
         return String.join(SalesforceConstants.REFERENCE_NAME_DELIMITER, nameParts);
       }
-      return name;
+      return field.getName();
     }
 
     /**
@@ -186,9 +187,14 @@ public class SObjectDescriptor {
       return hasParents() ? parents.get(parents.size() - 1) : null;
     }
 
+    @Nullable
+    public FieldType getFieldType() {
+      return field.getType();
+    }
+
     @Override
     public String toString() {
-      return "FieldDescriptor{" + "name='" + name + '\'' + ", parents=" + parents + '}';
+      return "FieldDescriptor{" + "name='" + field.getName() + '\'' + ", parents=" + parents + '}';
     }
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceSchemaUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceSchemaUtil.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
  */
 public class SalesforceSchemaUtil {
 
+  public static final Set<FieldType> COMPOUND_FIELDS = ImmutableSet.of(FieldType.address, FieldType.location);
+
   private static final Map<FieldType, Schema> SALESFORCE_TYPE_TO_CDAP_SCHEMA =
     new ImmutableMap.Builder<FieldType, Schema>()
     .put(FieldType._boolean, Schema.of(Schema.Type.BOOLEAN))

--- a/src/main/java/io/cdap/plugin/salesforce/parser/SalesforceQueryParser.java
+++ b/src/main/java/io/cdap/plugin/salesforce/parser/SalesforceQueryParser.java
@@ -45,9 +45,10 @@ public class SalesforceQueryParser {
    * Throws {@link SOQLParsingException} if query syntax is not valid.
    *
    * @param query SOQL query
+   * @return sObject descriptor
    */
-  public static void validateQuery(String query) {
-    getObjectDescriptorFromQuery(query);
+  public static SObjectDescriptor validateQuery(String query) {
+    return getObjectDescriptorFromQuery(query);
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/salesforce/parser/SalesforceQueryParser.java
+++ b/src/main/java/io/cdap/plugin/salesforce/parser/SalesforceQueryParser.java
@@ -42,16 +42,6 @@ public class SalesforceQueryParser {
   }
 
   /**
-   * Throws {@link SOQLParsingException} if query syntax is not valid.
-   *
-   * @param query SOQL query
-   * @return sObject descriptor
-   */
-  public static SObjectDescriptor validateQuery(String query) {
-    return getObjectDescriptorFromQuery(query);
-  }
-
-  /**
    * Returns part of SOQL query after select statement.
    *
    * @param query SOQL query

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.plugin.salesforce.SObjectDescriptor;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
+import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
 import io.cdap.plugin.salesforce.plugin.BaseSalesforceConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.slf4j.Logger;
@@ -96,6 +97,8 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
   /**
    * Generates SOQL based on given sObject name metadata and filter properties.
    * Includes only those sObject fields which are present in the schema.
+   * Flattens all compound fields by adding individual fields and excludes compound fields names to handle
+   * Bulk API limitation.
    * This allows to avoid pulling data from Salesforce for the fields which are not needed.
    *
    * @param sObjectName Salesforce object name
@@ -105,7 +108,8 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
    */
   protected String getSObjectQuery(String sObjectName, Schema schema) {
     try {
-      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName, getAuthenticatorCredentials());
+      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName, getAuthenticatorCredentials(),
+                                                                       SalesforceSchemaUtil.COMPOUND_FIELDS);
 
       List<String> sObjectFields = sObjectDescriptor.getFieldsNames();
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -17,18 +17,22 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.sforce.ws.ConnectionException;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
+import io.cdap.plugin.salesforce.SObjectDescriptor;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
 import io.cdap.plugin.salesforce.parser.SOQLParsingException;
 import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -116,11 +120,15 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   public void validate() {
     super.validate();
     if (!containsMacro(SalesforceSourceConstants.PROPERTY_QUERY) && !Strings.isNullOrEmpty(query)) {
+      SObjectDescriptor queryDescriptor;
       try {
-        SalesforceQueryParser.validateQuery(query);
+        queryDescriptor = SalesforceQueryParser.validateQuery(query);
       } catch (SOQLParsingException e) {
         throw new InvalidConfigPropertyException(String.format("Invalid SOQL query: '%s", query), e,
                                                  SalesforceSourceConstants.PROPERTY_QUERY);
+      }
+      if (canAttemptToEstablishConnection()) {
+        validateCompoundFields(queryDescriptor.getName(), queryDescriptor.getFieldsNames());
       }
     }
     if (!containsMacro(SalesforceSourceConstants.PROPERTY_QUERY)
@@ -139,6 +147,27 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
     Schema schema = getSchema();
     if (schema != null) {
       SalesforceSchemaUtil.validateFieldSchemas(schema);
+    }
+  }
+
+  private void validateCompoundFields(String sObjectName, List<String> fieldNames) {
+    try {
+      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName,
+                                                                       getAuthenticatorCredentials());
+      List<String> compoundFieldNames = sObjectDescriptor.getFields().stream()
+        .filter(fieldDescriptor -> fieldNames.contains(fieldDescriptor.getName()))
+        .filter(fieldDescriptor -> SalesforceSchemaUtil.COMPOUND_FIELDS.contains(fieldDescriptor.getFieldType()))
+        .map(SObjectDescriptor.FieldDescriptor::getName)
+        .collect(Collectors.toList());
+      if (!compoundFieldNames.isEmpty()) {
+        throw new InvalidConfigPropertyException(
+          String.format("Compound fields %s cannot be fetched via Bulk API. Please specify the individual "
+                          + "attributes instead of compound field name in SOQL query", compoundFieldNames),
+          SalesforceSourceConstants.PROPERTY_QUERY);
+      }
+    } catch (ConnectionException e) {
+      throw new IllegalStateException(
+        String.format("Cannot establish connection to Salesforce to describe SObject: '%s'", sObjectName), e);
     }
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -122,7 +122,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
     if (!containsMacro(SalesforceSourceConstants.PROPERTY_QUERY) && !Strings.isNullOrEmpty(query)) {
       SObjectDescriptor queryDescriptor;
       try {
-        queryDescriptor = SalesforceQueryParser.validateQuery(query);
+        queryDescriptor = SalesforceQueryParser.getObjectDescriptorFromQuery(query);
       } catch (SOQLParsingException e) {
         throw new InvalidConfigPropertyException(String.format("Invalid SOQL query: '%s", query), e,
                                                  SalesforceSourceConstants.PROPERTY_QUERY);
@@ -161,8 +161,11 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
         .collect(Collectors.toList());
       if (!compoundFieldNames.isEmpty()) {
         throw new InvalidConfigPropertyException(
-          String.format("Compound fields %s cannot be fetched via Bulk API. Please specify the individual "
-                          + "attributes instead of compound field name in SOQL query", compoundFieldNames),
+          String.format("Compound fields %s cannot be fetched when a SOQL query is given. "
+                          + "Please specify the individual attributes instead of compound field name in SOQL query. "
+                          + "For example, instead of 'Select BillingAddress ...', use "
+                          + "'Select BillingCountry, BillingCity, BillingStreet ...'",
+            compoundFieldNames),
           SalesforceSourceConstants.PROPERTY_QUERY);
       }
     } catch (ConnectionException e) {

--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
@@ -43,6 +43,11 @@ public class SalesforceSchemaUtilTest {
 
     List<SObjectDescriptor.FieldDescriptor> fieldDescriptors = Stream
       .of("Id", "Name", "Amount", "Percent", "ConversionRate", "IsWon", "CreatedDate", "CreatedDateTime", "CreatedTime")
+      .map(name -> {
+        Field field = new Field();
+        field.setName(name);
+        return field;
+      })
       .map(SObjectDescriptor.FieldDescriptor::new)
       .collect(Collectors.toList());
 

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSourceETLTest.java
@@ -171,15 +171,28 @@ public abstract class BaseSalesforceBatchSourceETLTest extends BaseSalesforceETL
   }
 
   protected CustomField createTextCustomField(String fullName) {
+    CustomField customField = createCustomField(fullName);
+    customField.setType(FieldType.Text);
+    customField.setLength(50);
+    customField.setDefaultValue("\"DefaultValue\"");
+    return customField;
+  }
+
+  protected CustomField createLocationCustomField(String fullName) {
+    CustomField customField = createCustomField(fullName);
+    customField.setType(FieldType.Location);
+    customField.setScale(3);
+    return customField;
+  }
+
+  private CustomField createCustomField(String fullName) {
     CustomField customField = new CustomField();
     customField.setFullName(fullName);
     // custom field name length can be 43 (max length + postfix `__c`)
     // substring field name to be within the label length limit
     customField.setLabel(fullName.substring(Math.max(0, fullName.length() - MAX_FIELD_NAME_LENGTH)));
-    customField.setType(FieldType.Text);
-    customField.setLength(50);
+    // to make it visible for current user
     customField.setRequired(true);
-    customField.setDefaultValue("\"DefaultValue\"");
     return customField;
   }
 

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReaderTest.java
@@ -15,14 +15,10 @@
  */
 package io.cdap.plugin.salesforce.plugin.source.batch;
 
-import com.sforce.soap.partner.Address;
 import com.sforce.soap.partner.sobject.SObject;
-import com.sforce.ws.bind.XmlObjectWrapper;
 import io.cdap.plugin.salesforce.SObjectDescriptor;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.etl.SObjectBuilder;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.xml.namespace.QName;
 
 public class SalesforceWideRecordReaderTest {
 
@@ -69,51 +64,6 @@ public class SalesforceWideRecordReaderTest {
     Assert.assertEquals(campaign.getField("Name"), resultMap.get("Campaign.Name"));
     Assert.assertEquals(campaign.getField("Id"), resultMap.get("Campaign.Id"));
   }
-
-  @Test
-  public void testTransformToMapCompoundField() throws JSONException {
-    SalesforceWideRecordReader recordReader = new SalesforceWideRecordReader(null, null);
-
-    Address address = new Address();
-    address.setCity("New York");
-    address.setCountry("US");
-    address.setPostalCode("10001");
-    address.setState("NY");
-
-    XmlObjectWrapper compoundFieldBillingAddress = new XmlObjectWrapper(address);
-    compoundFieldBillingAddress.setName(QName.valueOf("BillingAddress"));
-
-    SObject opportunity = new SObjectBuilder()
-      .setType("Opportunity")
-      .put("Id", "testOpportunityId")
-      .put("Name", "testOpportunity-1")
-      .put("Amount", "25000")
-      .put(compoundFieldBillingAddress.getName().getLocalPart(), compoundFieldBillingAddress)
-      .build();
-
-    List<SObjectDescriptor.FieldDescriptor> fieldDescriptors =
-      getFieldDescriptors("Id", "BillingAddress");
-    Map<String, String> resultMap = recordReader.transformToMap(opportunity, fieldDescriptors);
-
-    Assert.assertNotNull(resultMap);
-    Assert.assertEquals(fieldDescriptors.size(), resultMap.size());
-
-    Assert.assertEquals(opportunity.getField("Id"), resultMap.get("Id"));
-
-    String billingAddress = resultMap.get("BillingAddress");
-    Assert.assertNotNull(billingAddress);
-    // check compound field json
-    JSONObject jsonObject = new JSONObject(billingAddress);
-    Assert.assertEquals(address.getCity(), jsonObject.getString("city"));
-    Assert.assertEquals(address.getCountry(), jsonObject.getString("country"));
-    Assert.assertEquals(address.getPostalCode(), jsonObject.getString("postalCode"));
-    Assert.assertEquals(address.getState(), jsonObject.getString("state"));
-
-    Assert.assertTrue(jsonObject.isNull("street"));
-    Assert.assertTrue(jsonObject.isNull("latitude"));
-    Assert.assertTrue(jsonObject.isNull("longitude"));
-  }
-
 
   @Test
   public void testTransformToMapIncorrectReferenceField() {


### PR DESCRIPTION
1. Fail SOQL validations if compound fields are found
2. Generate sObject query without compound fields but with their individual fields to handle Bulk API limitation