### PR TITLE
CDAP-15320: Enhanced SObject incremental and range filters

### DIFF
--- a/docs/Salesforce-batchsource.md
+++ b/docs/Salesforce-batchsource.md
@@ -38,13 +38,8 @@ Examples:
 Salesforce and generate SOQL query (`select <FIELD_1, FIELD_2, ..., FIELD_N> from ${sObjectName}`). 
 Ignored if SOQL query is provided. 
 
-**Datetime Filter:** SObject query datetime filter is applied to system field `LastModifiedDate` to allow incremental 
-query. Filter is applied in `>` (greater than) comparison only and will be added to SObject query in a form of 
-where clause (`WHERE LastModifiedDate > ${datetimeFilter}`). 
-If value is not provided, it means all records to be read since the beginning of time. 
-The filter can be one of two types: 
-
-`SOQL Date Format` - string should be in Salesforce Date Formats. 
+**Last Modified After:** Filter data to only include records where the system field `LastModifiedDate` is greater than 
+or equal to the specified date. The date must be provided in the Salesforce date format:
 
 |              Format              |       Format Syntax       |          Example          |
 | -------------------------------- | ------------------------- | ------------------------- |
@@ -52,17 +47,52 @@ The filter can be one of two types:
 |                                  | YYYY-MM-DDThh:mm:ss-hh:mm | 1999-01-01T23:01:01-08:00 |
 |                                  | YYYY-MM-DDThh:mm:ssZ      | 1999-01-01T23:01:01Z      |
 
-`SOQL Date Literal` - fieldExpression to compare a range of values to the value in a datetime 
-field. Each literal is a range of time beginning with midnight (00:00:00). For example: `YESTERDAY`, `LAST_WEEK`, 
-`LAST_MONTH` ...
+If no value is provided, no lower bound for LastModifiedDate is applied.
 
-**Duration:** SObject query duration filter is applied to system field `LastModifiedDate` to allow range query. 
-Duration units set to `hours`. For example, if duration is '6' (6 hours) and the pipeline runs at 9am, it will read data 
-updated from 3am - 9am. Ignored if `datetimeFilter` is provided.
+**Last Modified Before:** Filter data to only include records where the system field `LastModifiedDate` is less than 
+the specified date. The date must be provided in the Salesforce date format:
 
-**Offset:** SObject query offset filter is applied to system field `LastModifiedDate` to allow range query. 
-Offset units set to `hours`. For example, if duration is '6' (6 hours) and the offset is '1' (1 hour) and the pipeline 
-runs at 9am, it will read data updated from 2am - 8am. Ignored if `datetimeFilter` is provided.
+|              Format              |       Format Syntax       |          Example          |
+| -------------------------------- | ------------------------- | ------------------------- |
+| Date, time, and time zone offset | YYYY-MM-DDThh:mm:ss+hh:mm | 1999-01-01T23:01:01+01:00 |
+|                                  | YYYY-MM-DDThh:mm:ss-hh:mm | 1999-01-01T23:01:01-08:00 |
+|                                  | YYYY-MM-DDThh:mm:ssZ      | 1999-01-01T23:01:01Z      |
+
+Specifying this along with `Last Modified After` allows reading data modified within a specific time window. 
+If no value is provided, no upper bound for `LastModifiedDate` is applied.
+
+**Duration:** Filter data read to only include records that were last modified within a time window of the specified size. 
+For example, if the duration is '6 hours' and the pipeline runs at 9am, it will read data that was last updated 
+from 3am (inclusive) to 9am (exclusive). The duration is specified using numbers and time units:
+
+|  Unit   |
+| ------- |
+| SECONDS |
+| MINUTES |
+| HOURS   |
+| DAYS    |
+| MONTHS  |
+| YEARS   |
+              
+Several units can be specified, but each unit can only be used once. For example, `2 days, 1 hours, 30 minutes`.
+The duration is ignored if a value is already specified for `Last Modified After` or `Last Modified Before`.
+
+**Offset:** Filter data to only read records where the system field `LastModifiedDate` is less than the logical start time 
+of the pipeline minus the given offset. For example, if duration is '6 hours' and the offset is '1 hours', and the pipeline 
+runs at 9am, data last modified between 2am (inclusive) and 8am (exclusive) will be read. 
+The duration is specified using numbers and time units:
+
+|  Unit   |
+| ------- |
+| SECONDS |
+| MINUTES |
+| HOURS   |
+| DAYS    |
+| MONTHS  |
+| YEARS   |
+
+Several units can be specified, but each unit can only be used once. For example, `2 days, 1 hours, 30 minutes`.
+The offset is ignored if a value is already specified for `Last Modified After` or `Last Modified Before`.
 
 **Schema:** The schema of output objects.
 The Salesforce types will be automatically mapped to schema types as shown below:

--- a/docs/SalesforceMultiObjects-batchsource.md
+++ b/docs/SalesforceMultiObjects-batchsource.md
@@ -32,14 +32,8 @@ For each white listed SObject, a SOQL query will be generated of the form:
 
 **Black List**: List of SObjects to avoid reading from. By default NONE of SObjects will be black listed.
 
-**Datetime Filter:** The amount of data to read. When a duration is specified, 
-a query filter will be applied on the `LastModifiedDate` system field. 
-Filter is applied in `>` (greater than) comparison only and will be added to SObject query in a form of 
-where clause (`WHERE LastModifiedDate > ${datetimeFilter}`). 
-If value is not provided, it means all records to be read since the beginning of time. 
-The filter can be one of two types: 
-
-`SOQL Date Format` - string should be in Salesforce Date Formats. 
+**Last Modified After:** Filter data to only include records where the system field `LastModifiedDate` is greater than 
+or equal to the specified date. The date must be provided in the Salesforce date format:
 
 |              Format              |       Format Syntax       |          Example          |
 | -------------------------------- | ------------------------- | ------------------------- |
@@ -47,17 +41,53 @@ The filter can be one of two types:
 |                                  | YYYY-MM-DDThh:mm:ss-hh:mm | 1999-01-01T23:01:01-08:00 |
 |                                  | YYYY-MM-DDThh:mm:ssZ      | 1999-01-01T23:01:01Z      |
 
-`SOQL Date Literal` - fieldExpression to compare a range of values to the value in a datetime 
-field. Each literal is a range of time beginning with midnight (00:00:00). For example: `YESTERDAY`, `LAST_WEEK`, 
-`LAST_MONTH` ...
+If no value is provided, no lower bound for LastModifiedDate is applied.
 
-**Duration:** SObject query duration filter is applied to system field `LastModifiedDate` to allow range query. 
-Duration units set to `hours`. For example, if duration is '6' (6 hours) and the pipeline runs at 9am, it will read data 
-updated from 3am - 9am. Ignored if `datetimeFilter` is provided.
+**Last Modified Before:** Filter data to only include records where the system field `LastModifiedDate` is less than 
+the specified date. The date must be provided in the Salesforce date format:
 
-**Offset:** SObject query offset filter is applied to system field `LastModifiedDate` to allow range query. 
-Offset units set to `hours`. For example, if duration is '6' (6 hours) and the offset is '1' (1 hour) and the pipeline 
-runs at 9am, it will read data updated from 2am - 8am. Ignored if `datetimeFilter` is provided.
+|              Format              |       Format Syntax       |          Example          |
+| -------------------------------- | ------------------------- | ------------------------- |
+| Date, time, and time zone offset | YYYY-MM-DDThh:mm:ss+hh:mm | 1999-01-01T23:01:01+01:00 |
+|                                  | YYYY-MM-DDThh:mm:ss-hh:mm | 1999-01-01T23:01:01-08:00 |
+|                                  | YYYY-MM-DDThh:mm:ssZ      | 1999-01-01T23:01:01Z      |
+
+Specifying this along with `Last Modified After` allows reading data modified within a specific time window. 
+If no value is provided, no upper bound for `LastModifiedDate` is applied.
+
+**Duration:** Filter data read to only include records that were last modified within a time window of the specified size. 
+For example, if the duration is '6 hours' and the pipeline runs at 9am, it will read data that was last updated 
+from 3am (inclusive) to 9am (exclusive). The duration is specified using numbers and time units:
+
+|  Unit   |
+| ------- |
+| SECONDS |
+| MINUTES |
+| HOURS   |
+| DAYS    |
+| MONTHS  |
+| YEARS   |
+
+              
+Several units can be specified, but each unit can only be used once. For example, `2 days, 1 hours, 30 minutes`.
+The duration is ignored if a value is already specified for `Last Modified After` or `Last Modified Before`.
+
+**Offset:** Filter data to only read records where the system field `LastModifiedDate` is less than the logical start time 
+of the pipeline minus the given offset. For example, if duration is '6 hours' and the offset is '1 hours', and the pipeline 
+runs at 9am, data last modified between 2am (inclusive) and 8am (exclusive) will be read. 
+The duration is specified using numbers and time units:
+
+|  Unit   |
+| ------- |
+| SECONDS |
+| MINUTES |
+| HOURS   |
+| DAYS    |
+| MONTHS  |
+| YEARS   |
+
+Several units can be specified, but each unit can only be used once. For example, `2 days, 1 hours, 30 minutes`.
+The offset is ignored if a value is already specified for `Last Modified After` or `Last Modified Before`.
 
 **SObject Name Field**: The name of the field that holds the SObject name. 
 Must not be the name of any SObject column that will be read. Defaults to `tablename`.

--- a/src/main/java/io/cdap/plugin/salesforce/SObjectFilterDescriptor.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SObjectFilterDescriptor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * SObject query datetime filter handler. Can be of three types:
+ * <ul>
+ * <li>Interval - filter using provided start and end datetime</li>
+ * <li>Range - filter calculated from provided start time, duration and offset</li>
+ * <li>NoOp - filter initialized with null</li>
+ * </ul>
+ */
+public final class SObjectFilterDescriptor {
+
+  private static final SObjectFilterDescriptor NO_OP_FILTER_INSTANCE = new SObjectFilterDescriptor(null, null);
+
+  @Nullable
+  private final ZonedDateTime startTime;
+  @Nullable
+  private final ZonedDateTime endTime;
+
+  public static SObjectFilterDescriptor noOp() {
+    return NO_OP_FILTER_INSTANCE;
+  }
+
+  public static SObjectFilterDescriptor interval(@Nullable ZonedDateTime startTime,
+                                                 @Nullable ZonedDateTime endTime) {
+    return startTime == null && endTime == null
+      ? NO_OP_FILTER_INSTANCE
+      : new SObjectFilterDescriptor(startTime, endTime);
+  }
+
+  public static SObjectFilterDescriptor range(long logicalStartTime,
+                                              Map<ChronoUnit, Integer> duration,
+                                              Map<ChronoUnit, Integer> offset) {
+    return calculateRangeFilter(toZonedDateTime(logicalStartTime), duration, offset);
+  }
+
+  private SObjectFilterDescriptor(@Nullable ZonedDateTime startTime,
+                                  @Nullable ZonedDateTime endTime) {
+    this.startTime = startTime;
+    this.endTime = endTime;
+  }
+
+  @Nullable
+  public ZonedDateTime getStartTime() {
+    return startTime;
+  }
+
+  @Nullable
+  public ZonedDateTime getEndTime() {
+    return endTime;
+  }
+
+  public boolean isNoOp() {
+    return equals(NO_OP_FILTER_INSTANCE);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startTime, endTime);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SObjectFilterDescriptor that = (SObjectFilterDescriptor) o;
+    return Objects.equals(startTime, that.startTime) &&
+      Objects.equals(endTime, that.endTime);
+  }
+
+  @Override
+  public String toString() {
+    return "SObjectFilterDescriptor{" +
+      "startTime=" + startTime +
+      ", endTime=" + endTime +
+      '}';
+  }
+
+  /**
+   * Generates Range or NoOp SObject query filter using provided values.
+   *
+   * @param logicalStartTime application start time
+   * @param duration         filter duration
+   * @param offset           filter offset
+   * @return instance of SObjectFilterDescriptor
+   */
+  private static SObjectFilterDescriptor calculateRangeFilter(ZonedDateTime logicalStartTime,
+                                                              Map<ChronoUnit, Integer> duration,
+                                                              Map<ChronoUnit, Integer> offset) {
+    if (duration.isEmpty() && offset.isEmpty()) {
+      // no filter is required
+      return NO_OP_FILTER_INSTANCE;
+    }
+
+    ZonedDateTime endTime = logicalStartTime;
+    for (Map.Entry<ChronoUnit, Integer> entry : offset.entrySet()) {
+      endTime = endTime.minus(entry.getValue(), entry.getKey());
+    }
+    ZonedDateTime startTime = endTime;
+    for (Map.Entry<ChronoUnit, Integer> entry : duration.entrySet()) {
+      startTime = startTime.minus(entry.getValue(), entry.getKey());
+    }
+    // if duration and offset are zero (Example: 0 Hours)
+    if (startTime.equals(endTime) && endTime.equals(logicalStartTime)) {
+      // no filter is required
+      return NO_OP_FILTER_INSTANCE;
+    }
+    return new SObjectFilterDescriptor(startTime.equals(endTime) ? null : startTime, endTime);
+  }
+
+  /**
+   * Transforms provided time from millis to {@link ZonedDateTime}.
+   *
+   * @param timeInMillis logical start time
+   * @return datetime in UTC timezone
+   */
+  private static ZonedDateTime toZonedDateTime(long timeInMillis) {
+    return ZonedDateTime.ofInstant(Instant.ofEpochMilli(timeInMillis), ZoneOffset.UTC);
+  }
+}

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -35,6 +35,6 @@ public class SalesforceConstants {
   public static final String CONFIG_CONSUMER_SECRET = "mapred.salesforce.consumer.secret";
   public static final String CONFIG_LOGIN_URL = "mapred.salesforce.login.url";
 
-  public static final int INTERVAL_FILTER_MIN_VALUE = 0;
+  public static final int RANGE_FILTER_MIN_VALUE = 0;
   public static final int SOQL_MAX_LENGTH = 20000;
 }

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceQueryUtil.java
@@ -15,11 +15,8 @@
  */
 package io.cdap.plugin.salesforce;
 
-import com.google.common.base.Strings;
 import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -27,9 +24,8 @@ import java.util.List;
  * Provides Salesforce query utility methods.
  */
 public class SalesforceQueryUtil {
-  private static final String NO_OP_FILTER = "";
   private static final String LESS_THAN = "<";
-  private static final String GREATER_THAN = ">";
+  private static final String GREATER_THAN_OR_EQUAL = ">=";
 
   private static final String SELECT = "SELECT ";
   private static final String FROM = " FROM ";
@@ -41,41 +37,21 @@ public class SalesforceQueryUtil {
   private static final String FIELD_ID = "Id";
 
   /**
-   * Creates SObject query with filter if provided. Uses current datetime in UTC timezone for range filter
-   * by default.
-   *
-   * @param fields         query fields
-   * @param sObjectName    SObject name
-   * @param duration       SObject query duration
-   * @param offset         SObject query offset
-   * @param datetimeFilter SObject query datetime filter
-   * @return SOQL with filter if provided
-   */
-  public static String createSObjectQuery(List<String> fields, String sObjectName, long duration,
-                                          long offset, String datetimeFilter) {
-    return createSObjectQuery(fields, sObjectName, ZonedDateTime.now(ZoneOffset.UTC), duration, offset, datetimeFilter);
-  }
-
-  /**
    * Creates SObject query with filter if provided.
    *
-   * @param fields         query fields
-   * @param sObjectName    SObject name
-   * @param dateTime       application start time
-   * @param duration       SObject query duration
-   * @param offset         SObject query offset
-   * @param datetimeFilter SObject query datetime filter
-   * @return SOQL with filter if provided
+   * @param fields           query fields
+   * @param sObjectName      SObject name
+   * @param filterDescriptor SObject date filter descriptor
+   * @return SOQL with filter if SObjectFilterDescriptor type is not NoOp
    */
-  public static String createSObjectQuery(List<String> fields, String sObjectName, ZonedDateTime dateTime,
-                                          long duration, long offset, String datetimeFilter) {
+  public static String createSObjectQuery(List<String> fields, String sObjectName,
+                                          SObjectFilterDescriptor filterDescriptor) {
     StringBuilder query = new StringBuilder()
       .append(SELECT).append(String.join(",", fields))
       .append(FROM).append(sObjectName);
 
-    String sObjectFilter = generateSObjectFilter(dateTime, duration, offset, datetimeFilter);
-    if (!Strings.isNullOrEmpty(sObjectFilter)) {
-      query.append(WHERE).append(sObjectFilter);
+    if (!filterDescriptor.isNoOp()) {
+      query.append(WHERE).append(generateSObjectFilter(filterDescriptor));
     }
     return query.toString();
   }
@@ -111,60 +87,24 @@ public class SalesforceQueryUtil {
   /**
    * Generates SObject query filter based on provided values.
    *
-   * @param dateTime       application start time
-   * @param duration       SObject query duration
-   * @param offset         SObject query offset
-   * @param datetimeFilter SObject query datetime filter
-   * @return interval or datetime filter based on provided values
+   * @param filterDescriptor filter options holder
+   * @return datetime, range or no-op filter
    */
-  private static String generateSObjectFilter(ZonedDateTime dateTime, long duration, long offset,
-                                              String datetimeFilter) {
-    return Strings.isNullOrEmpty(datetimeFilter) || datetimeFilter.trim().isEmpty()
-      ? generateRangeFilter(FIELD_LAST_MODIFIED_DATE, dateTime, duration, offset)
-      : generateIncrementalFilter(FIELD_LAST_MODIFIED_DATE, datetimeFilter);
-  }
-
-  /**
-   * Generates range date filter based on duration and offset.
-   * <p>
-   * Examples:
-   * <ul>
-   * <li>if duration is '6' (6 hours) and the pipeline runs at 9am, it will read data updated
-   * from 3am - 9am.</li>
-   *
-   * <li>if duration is '6' and the offset is '1' and the pipeline runs at 9am, it will read
-   * data updated from 2am - 8am.</li>
-   * </ul>
-   *
-   * @param fieldName dateTime field name
-   * @param dateTime  pipeline start time
-   * @param duration  pipeline fetch duration
-   * @param offset    offset from pipeline start time
-   * @return datetime filter or empty string if duration is not set
-   */
-  private static String generateRangeFilter(String fieldName, ZonedDateTime dateTime, long duration,
-                                            long offset) {
-    if (duration <= SalesforceConstants.INTERVAL_FILTER_MIN_VALUE) {
-      // no filter is required
-      return NO_OP_FILTER;
+  private static String generateSObjectFilter(SObjectFilterDescriptor filterDescriptor) {
+    StringBuilder filter = new StringBuilder();
+    if (filterDescriptor.getStartTime() != null) {
+      filter.append(FIELD_LAST_MODIFIED_DATE)
+        .append(GREATER_THAN_OR_EQUAL)
+        .append(filterDescriptor.getStartTime().format(DateTimeFormatter.ISO_DATE_TIME));
     }
-    ZonedDateTime endTime = dateTime.minusHours(offset);
-    ZonedDateTime startTime = endTime.minusHours(duration);
-    return fieldName + GREATER_THAN + startTime.format(DateTimeFormatter.ISO_DATE_TIME) +
-      AND +
-      fieldName + LESS_THAN + endTime.format(DateTimeFormatter.ISO_DATE_TIME);
-  }
-
-  /**
-   * Generates incremental date filter based on provided datetimeValue.
-   *
-   * @param datetimeValue dateTime in ISO format or SOQL date literal
-   * @return datetime filter or empty string if datetimeValue is blank
-   */
-  private static String generateIncrementalFilter(String fieldName, String datetimeValue) {
-    // extract first value from datetimeValue to avoid SQL injection. Delimiter is space.
-    // Example: `   2018-01-01 OR Id LIKE '%'  ` replaced with `2018-01-01`
-    String firstValue = datetimeValue.trim().split(" ", 2)[0];
-    return fieldName + GREATER_THAN + firstValue;
+    if (filterDescriptor.getEndTime() != null) {
+      if (filter.length() > 0) {
+        filter.append(AND);
+      }
+      filter.append(FIELD_LAST_MODIFIED_DATE)
+        .append(LESS_THAN)
+        .append(filterDescriptor.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
+    }
+    return filter.toString();
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
@@ -66,7 +66,7 @@ public class SalesforceBatchMultiSource extends BatchSource<Schema, Map<String, 
   @Override
   public void prepareRun(BatchSourceContext context) throws ConnectionException {
     config.validate();
-    List<String> queries = config.getQueries();
+    List<String> queries = config.getQueries(context.getLogicalStartTime());
     Map<String, Schema> schemas = config.getSObjectsSchemas(queries);
 
     // propagate schema for each SObject for multi sink plugin

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -38,7 +38,6 @@ import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConsta
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.ws.rs.Path;
 
 /**
  * Plugin returns records from Salesforce using provided by user SOQL query or SObject.
@@ -98,7 +97,7 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
         .map(Schema.Field::getName)
         .collect(Collectors.toList()));
 
-    String query = config.getQuery();
+    String query = config.getQuery(context.getLogicalStartTime());
     String sObjectName = SObjectDescriptor.fromQuery(query).getName();
     context.setInput(Input.of(config.referenceName, new SalesforceInputFormatProvider(config,
         Collections.singletonList(query), ImmutableMap.of(sObjectName, schema.toString()), null)));
@@ -123,9 +122,8 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
    * @param config Salesforce Source Batch config
    * @return schema calculated from query
    */
-  @Path("getSchema")
-  public Schema getSchema(SalesforceSourceConfig config) {
-    String query = config.getQuery();
+  private Schema getSchema(SalesforceSourceConfig config) {
+    String query = config.getQuery(System.currentTimeMillis());
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     try {
       return SalesforceSchemaUtil.getSchema(config.getAuthenticatorCredentials(), sObjectDescriptor);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
@@ -74,14 +74,15 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
                               String username,
                               String password,
                               String loginUrl,
-                              @Nullable String datetimeFilter,
-                              @Nullable Integer duration,
-                              @Nullable Integer offset,
+                              @Nullable String datetimeAfter,
+                              @Nullable String datetimeBefore,
+                              @Nullable String duration,
+                              @Nullable String offset,
                               @Nullable String whiteList,
                               @Nullable String blackList,
                               @Nullable String sObjectNameField) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
-      datetimeFilter, duration, offset);
+          datetimeAfter, datetimeBefore, duration, offset);
     this.whiteList = whiteList;
     this.blackList = blackList;
     this.sObjectNameField = sObjectNameField;
@@ -137,11 +138,12 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
   /**
    * Generates list of SObject queries based on given list of SObjects and incremental filters if any.
    *
+   * @param logicalStartTime application start time
    * @return list of SObject queries
    */
-  public List<String> getQueries() {
+  public List<String> getQueries(long logicalStartTime) {
     List<String> queries = getSObjects().parallelStream()
-      .map(sObject -> getSObjectQuery(sObject, null))
+      .map(sObject -> getSObjectQuery(sObject, null, logicalStartTime))
       .collect(Collectors.toList());
 
     if (queries.isEmpty()) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -68,12 +68,13 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
                                 String loginUrl,
                                 @Nullable String query,
                                 @Nullable String sObjectName,
-                                @Nullable String datetimeFilter,
-                                @Nullable Integer duration,
-                                @Nullable Integer offset,
+                                @Nullable String datetimeAfter,
+                                @Nullable String datetimeBefore,
+                                @Nullable String duration,
+                                @Nullable String offset,
                                 @Nullable String schema) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
-      datetimeFilter, duration, offset);
+          datetimeAfter, datetimeBefore, duration, offset);
     this.query = query;
     this.sObjectName = sObjectName;
     this.schema = schema;
@@ -83,10 +84,11 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
    * Returns SOQL to retrieve data from Salesforce. If user has provided SOQL, returns given SOQL.
    * If user has provided sObject name, generates SOQL based on sObject metadata and provided filters.
    *
+   * @param logicalStartTime application start time
    * @return SOQL query
    */
-  public String getQuery() {
-    String soql = isSoqlQuery() ? query : getSObjectQuery(sObjectName, getSchema());
+  public String getQuery(long logicalStartTime) {
+    String soql = isSoqlQuery() ? query : getSObjectQuery(sObjectName, getSchema(), logicalStartTime);
     return Objects.requireNonNull(soql).trim();
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -20,7 +20,8 @@ package io.cdap.plugin.salesforce.plugin.source.batch.util;
  */
 public class SalesforceSourceConstants {
 
-  public static final String PROPERTY_DATETIME_FILTER = "datetimeFilter";
+  public static final String PROPERTY_DATETIME_AFTER = "datetimeAfter";
+  public static final String PROPERTY_DATETIME_BEFORE = "datetimeBefore";
   public static final String PROPERTY_DURATION = "duration";
   public static final String PROPERTY_OFFSET = "offset";
   public static final String PROPERTY_SCHEMA = "schema";
@@ -36,8 +37,6 @@ public class SalesforceSourceConstants {
   public static final String CONFIG_SCHEMAS = "mapred.salesforce.input.schemas";
   public static final String CONFIG_SOBJECT_NAME_FIELD = "mapred.salesforce.input.sObjectNameField";
 
-  public static final int DURATION_DEFAULT = 0;
-  public static final int OFFSET_DEFAULT = 0;
   public static final int WIDE_QUERY_MAX_BATCH_COUNT = 2000;
 
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.plugin.salesforce.SObjectDescriptor;
+import io.cdap.plugin.salesforce.SObjectFilterDescriptor;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
@@ -315,7 +316,7 @@ public class SalesforceStreamingSourceConfig extends BaseSalesforceConfig implem
                                                                        getAuthenticatorCredentials(), typesToSkip);
 
       String sObjectQuery = SalesforceQueryUtil.createSObjectQuery(sObjectDescriptor.getFieldsNames(), sObjectName,
-                                                                   0, 0, "");
+                                                                   SObjectFilterDescriptor.noOp());
 
       LOG.debug("Generated SObject query: '{}'", sObjectQuery);
       return sObjectQuery;

--- a/src/test/java/io/cdap/plugin/salesforce/SObjectFilterDescriptorTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SObjectFilterDescriptorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+/**
+ * Tests for {@link SObjectFilterDescriptor}.
+ */
+public class SObjectFilterDescriptorTest {
+
+  @Test
+  public void testIsNoOp() {
+    Stream.of(
+      SObjectFilterDescriptor.noOp(),
+      SObjectFilterDescriptor.interval(null, null),
+      SObjectFilterDescriptor.range(System.currentTimeMillis(), Collections.emptyMap(), Collections.emptyMap()),
+      SObjectFilterDescriptor.range(System.currentTimeMillis(),
+                                    Collections.singletonMap(ChronoUnit.DAYS, 0),
+                                    Collections.singletonMap(ChronoUnit.HOURS, 0))
+      )
+      .forEach(filter -> Assert.assertTrue(String.format("Filter must be no-op '%s'", filter), filter.isNoOp()));
+  }
+
+  @Test
+  public void testRangeDuration() {
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    SObjectFilterDescriptor filter = SObjectFilterDescriptor.range(
+      now.toInstant().toEpochMilli(),
+      Collections.singletonMap(ChronoUnit.HOURS, 6),
+      Collections.emptyMap());
+
+    Assert.assertEquals(now.minusHours(6), filter.getStartTime());
+    Assert.assertEquals(now, filter.getEndTime());
+  }
+
+  @Test
+  public void testRangeOffset() {
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    SObjectFilterDescriptor filter = SObjectFilterDescriptor.range(
+      now.toInstant().toEpochMilli(),
+      Collections.emptyMap(),
+      Collections.singletonMap(ChronoUnit.HOURS, 2));
+
+    Assert.assertNull(filter.getStartTime());
+    Assert.assertEquals(now.minusHours(2), filter.getEndTime());
+  }
+
+  @Test
+  public void testRangeDurationAndOffset() {
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    SObjectFilterDescriptor filter = SObjectFilterDescriptor.range(
+      now.toInstant().toEpochMilli(),
+      Collections.singletonMap(ChronoUnit.HOURS, 6),
+      Collections.singletonMap(ChronoUnit.HOURS, 2));
+
+    Assert.assertEquals(now.minusHours(2).minusHours(6), filter.getStartTime());
+    Assert.assertEquals(now.minusHours(2), filter.getEndTime());
+  }
+}

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSourceETLTest.java
@@ -139,13 +139,18 @@ public abstract class BaseSalesforceBatchSourceETLTest extends BaseSalesforceETL
   }
 
   protected List<StructuredRecord> getResultsBySObjectQuery(String sObjectName,
-                                                            String datetimeFilter,
+                                                            String datetimeAfter,
+                                                            String datetimeBefore,
                                                             String schema) throws Exception {
     ImmutableMap.Builder<String, String> propsBuilder = getBaseProperties(REFERENCE_NAME)
       .put(SalesforceSourceConstants.PROPERTY_SOBJECT_NAME, sObjectName);
 
-    if (datetimeFilter != null) {
-      propsBuilder.put(SalesforceSourceConstants.PROPERTY_DATETIME_FILTER, datetimeFilter);
+    if (datetimeAfter != null) {
+      propsBuilder.put(SalesforceSourceConstants.PROPERTY_DATETIME_AFTER, datetimeAfter);
+    }
+
+    if (datetimeBefore != null) {
+      propsBuilder.put(SalesforceSourceConstants.PROPERTY_DATETIME_BEFORE, datetimeBefore);
     }
 
     if (schema != null) {

--- a/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSourceETLTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableSet;
 import com.sforce.soap.metadata.CustomField;
 import com.sforce.soap.partner.DescribeSObjectResult;
 import com.sforce.soap.partner.Field;
-import com.sforce.soap.partner.Location;
 import com.sforce.soap.partner.sobject.SObject;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -222,7 +221,7 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
       .map(Field::getName)
       .collect(Collectors.toList());
 
-    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null);
+    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null, null);
 
     Assert.assertEquals(1, results.size());
 
@@ -251,7 +250,7 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
     Schema providedSchema = Schema.recordOf("output",
       Schema.Field.of("Name", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
 
-    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, providedSchema.toString());
+    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null, providedSchema.toString());
 
     Assert.assertEquals(1, results.size());
 
@@ -271,7 +270,7 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
 
     addSObjects(sObjects, false);
 
-    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null);
+    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null, null);
 
     Assert.assertEquals(names.size(), results.size());
 
@@ -293,7 +292,9 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
 
     addSObjects(Collections.singletonList(sObject1), false);
 
-    String dateTimeFilter = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE_TIME);
+    ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+    String datetimeAfter = now.plusSeconds(1).format(DateTimeFormatter.ISO_DATE_TIME);
+    String datetimeBefore = now.plusHours(1).format(DateTimeFormatter.ISO_DATE_TIME);
 
     // we can not modify LastModifiedDate, add new record after 2 seconds to be able to check filtering
     TimeUnit.SECONDS.sleep(2);
@@ -305,7 +306,7 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
 
     addSObjects(Collections.singletonList(sObject2), false);
 
-    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, dateTimeFilter, null);
+    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, datetimeAfter, datetimeBefore, null);
 
     Assert.assertEquals(1, results.size());
     Assert.assertEquals("Wilma", results.get(0).get("Name"));
@@ -379,7 +380,7 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
       .filter(name -> !customField.getFullName().equals(name)) // exclude compound field name
       .collect(Collectors.toList());
 
-    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null);
+    List<StructuredRecord> results = getResultsBySObjectQuery(sObjectName, null, null, null);
 
     Assert.assertEquals(1, results.size());
 

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -28,9 +28,10 @@ public class SalesforceSourceConfigBuilder {
   private String loginUrl;
   private String query;
   private String sObjectName;
-  private String datetimeFilter;
-  private Integer duration;
-  private Integer offset;
+  private String datetimeAfter;
+  private String datetimeBefore;
+  private String duration;
+  private String offset;
   private String schema;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
@@ -73,17 +74,22 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
-  public SalesforceSourceConfigBuilder setDatetimeFilter(String datetimeFilter) {
-    this.datetimeFilter = datetimeFilter;
+  public SalesforceSourceConfigBuilder setDatetimeAfter(String datetimeAfter) {
+    this.datetimeAfter = datetimeAfter;
     return this;
   }
 
-  public SalesforceSourceConfigBuilder setDuration(Integer duration) {
+  public SalesforceSourceConfigBuilder setDatetimeBefore(String datetimeBefore) {
+    this.datetimeBefore = datetimeBefore;
+    return this;
+  }
+
+  public SalesforceSourceConfigBuilder setDuration(String duration) {
     this.duration = duration;
     return this;
   }
 
-  public SalesforceSourceConfigBuilder setOffset(Integer offset) {
+  public SalesforceSourceConfigBuilder setOffset(String offset) {
     this.offset = offset;
     return this;
   }
@@ -95,6 +101,6 @@ public class SalesforceSourceConfigBuilder {
 
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
-                                      query, sObjectName, datetimeFilter, duration, offset, schema);
+                                      query, sObjectName, datetimeAfter, datetimeBefore, duration, offset, schema);
   }
 }

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -78,26 +78,56 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Datetime Filter",
-          "name": "datetimeFilter",
+          "label": "Last Modified After",
+          "name": "datetimeAfter",
           "widget-attributes" : {
-            "placeholder": "Datetime filter in SOQL Date or Date Literal format"
+            "placeholder": "YYYY-MM-DDThh:mm:ssZ (ex: 2019-01-01T00:00:00Z)"
           }
         },
         {
           "widget-type": "textbox",
+          "label": "Last Modified Before",
+          "name": "datetimeBefore",
+          "widget-attributes" : {
+            "placeholder": "YYYY-MM-DDThh:mm:ssZ (ex: 2019-01-01T00:00:00Z)"
+          }
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
           "label": "Duration",
           "name": "duration",
-          "widget-attributes" : {
-            "default": "0"
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "delimiter": ",",
+            "kv-delimiter": " ",
+            "dropdownOptions": [
+              "SECONDS",
+              "MINUTES",
+              "HOURS",
+              "DAYS",
+              "MONTHS",
+              "YEARS"
+            ],
+            "key-placeholder": "Duration"
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "keyvalue-dropdown",
           "label": "Offset",
           "name": "offset",
-          "widget-attributes" : {
-            "default": "0"
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "delimiter": ",",
+            "kv-delimiter": " ",
+            "dropdownOptions": [
+              "SECONDS",
+              "MINUTES",
+              "HOURS",
+              "DAYS",
+              "MONTHS",
+              "YEARS"
+            ],
+            "key-placeholder": "Offset"
           }
         }
       ]

--- a/widgets/SalesforceMultiObjects-batchsource.json
+++ b/widgets/SalesforceMultiObjects-batchsource.json
@@ -74,26 +74,56 @@
       "properties": [
         {
           "widget-type": "textbox",
-          "label": "Datetime Filter",
-          "name": "datetimeFilter",
+          "label": "Last Modified After",
+          "name": "datetimeAfter",
           "widget-attributes" : {
-            "placeholder": "Datetime filter in SOQL Date or Date Literal format"
+            "placeholder": "YYYY-MM-DDThh:mm:ssZ (ex: 2019-01-01T00:00:00Z)"
           }
         },
         {
           "widget-type": "textbox",
+          "label": "Last Modified Before",
+          "name": "datetimeBefore",
+          "widget-attributes" : {
+            "placeholder": "YYYY-MM-DDThh:mm:ssZ (ex: 2019-01-01T00:00:00Z)"
+          }
+        },
+        {
+          "widget-type": "keyvalue-dropdown",
           "label": "Duration",
           "name": "duration",
-          "widget-attributes" : {
-            "default": "0"
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "delimiter": ",",
+            "kv-delimiter": " ",
+            "dropdownOptions": [
+              "SECONDS",
+              "MINUTES",
+              "HOURS",
+              "DAYS",
+              "MONTHS",
+              "YEARS"
+            ],
+            "key-placeholder": "Duration"
           }
         },
         {
-          "widget-type": "textbox",
+          "widget-type": "keyvalue-dropdown",
           "label": "Offset",
           "name": "offset",
-          "widget-attributes" : {
-            "default": "0"
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "delimiter": ",",
+            "kv-delimiter": " ",
+            "dropdownOptions": [
+              "SECONDS",
+              "MINUTES",
+              "HOURS",
+              "DAYS",
+              "MONTHS",
+              "YEARS"
+            ],
+            "key-placeholder": "Offset"
           }
         }
       ]


### PR DESCRIPTION
1. Replace 'Datetime filter' with 'Last Modified After' and 'Last Modified Before' filters
2. Drop support for the date literals (yesterday, last_month, etc)
3. Add multiple unit type support to duration and offset filters