### PR TITLE
update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,13 +30,13 @@
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- version properties -->
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.0.0</cdap.version>
     <junit.version>4.12</junit.version>
     <commons.io.version>2.6</commons.io.version>
     <commons.lang.version>2.6</commons.lang.version>
     <hadoop.version>2.3.0</hadoop.version>
     <spark2.version>2.1.3</spark2.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+    <hydrator.version>2.2.0</hydrator.version>
     <commons.version>3.8.1</commons.version>
     <salesforce.api.version>45.0.0</salesforce.api.version>
     <cometd.java.client.version>4.0.0</cometd.java.client.version>
@@ -44,7 +44,7 @@
     <mockito.version>1.10.19</mockito.version>
     <commons.csv.version>1.6</commons.csv.version>
     <jackson.version>1.9.13</jackson.version>
-    <jackson2.version>2.6.7</jackson2.version>
+    <jackson2.version>2.9.9</jackson2.version>
     <json.version>20180813</json.version>
     <awaitility.version>3.1.6</awaitility.version>
     <commons-logging.version>1.2</commons-logging.version>


### PR DESCRIPTION
Use non-snapshot versions of CDAP dependencies and update jackson
to a newer version.