### PR TITLE
CDAP-15455. Support Upsert and Update operations for SFDC Sink

### DIFF
--- a/docs/Salesforce-batchsink.md
+++ b/docs/Salesforce-batchsink.md
@@ -27,10 +27,19 @@ A Salesforce connected application must be created in order to get a client secr
 
 **SObject Name:** Salesforce object name to insert records into.
 
-**Max records per batch:** Maximum number of records to include in a batch when writing to Salesforce.
+**Operation:** Operation used for writing data into Salesforce.<br>
+Insert - adds records.<br>
+Upsert - upserts the records. Salesforce will decide if sObjects 
+are the same using external id field.<br>
+Update - updates existing records based on Id field.
+
+**Upsert External ID Field:** External id field name. It is used only if operation is upsert.
+The field specified can be either 'Id' or any customly created field, which has external id attribute set.
+
+**Max Records Per Batch:** Maximum number of records to include in a batch when writing to Salesforce.
 This value cannot be greater than 10,000.
 
-**Max bytes per batch:** Maximum size in bytes of a batch of records when writing to Salesforce.
+**Max Bytes Per Batch:** Maximum size in bytes of a batch of records when writing to Salesforce.
 This value cannot be greater than 10,000,000.
 
 **Error Handling:** Strategy used to handle erroneous records.<br>

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
@@ -72,12 +72,17 @@ public final class SalesforceBulkUtil {
    * @throws AsyncApiException if there is an issue creating the job
    */
   public static JobInfo createJob(BulkConnection bulkConnection,
-                                  String sObject, OperationEnum operationEnum) throws AsyncApiException {
+                                  String sObject, OperationEnum operationEnum,
+                                  String externalIdField) throws AsyncApiException {
     JobInfo job = new JobInfo();
     job.setObject(sObject);
     job.setOperation(operationEnum);
     job.setConcurrencyMode(ConcurrencyMode.Parallel);
     job.setContentType(ContentType.CSV);
+    if (externalIdField != null) {
+      job.setExternalIdFieldName(externalIdField);
+    }
+
     job = bulkConnection.createJob(job);
     Preconditions.checkState(job.getId() != null, "Couldn't get job ID. There was a problem in creating the " +
       "batch job");
@@ -112,7 +117,7 @@ public final class SalesforceBulkUtil {
     throws AsyncApiException, IOException {
 
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
-    JobInfo job = createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.query);
+    JobInfo job = createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.query, null);
 
     try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
       bulkConnection.createBatchFromStream(job, bout);

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceSchemaUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceSchemaUtil.java
@@ -107,6 +107,16 @@ public class SalesforceSchemaUtil {
   }
 
   /**
+   * Works like {@link SalesforceSchemaUtil#checkCompatibility(Schema, Schema, boolean)}
+   * except that checking nullable is always on.
+   *
+   * @see SalesforceSchemaUtil#checkCompatibility(Schema, Schema, boolean)
+   */
+  public static void checkCompatibility(Schema actualSchema, Schema providedSchema) {
+    checkCompatibility(actualSchema, providedSchema, true);
+  }
+
+  /**
    * Checks two schemas compatibility based on the following rules:
    * <ul>
    *   <li>Actual schema must have fields indicated in the provided schema.</li>
@@ -117,10 +127,11 @@ public class SalesforceSchemaUtil {
    *
    * @param actualSchema schema calculated based on Salesforce metadata information
    * @param providedSchema schema provided in the configuration
+   * @param checkNullable if true, checks for nullability of fields in schema are triggered.
    */
-  public static void checkCompatibility(Schema actualSchema, Schema providedSchema) {
+  public static void checkCompatibility(Schema actualSchema, Schema providedSchema, boolean checkNullable) {
     for (Schema.Field providedField : Objects.requireNonNull(providedSchema.getFields())) {
-      Schema.Field actualField = actualSchema.getField(providedField.getName());
+      Schema.Field actualField = actualSchema.getField(providedField.getName(), true);
       if (actualField == null) {
         throw new IllegalArgumentException(
           String.format("Field '%s' does not exist in Salesforce", providedField.getName()));
@@ -142,7 +153,7 @@ public class SalesforceSchemaUtil {
             providedField.getName(), providedFieldSchema, actualFieldSchema));
       }
 
-      if (isActualFieldNullable && !isProvidedFieldNullable) {
+      if (checkNullable && isActualFieldNullable && !isProvidedFieldNullable) {
         throw new IllegalArgumentException(String.format("Field '%s' should be nullable", providedField.getName()));
       }
     }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormat.java
@@ -70,12 +70,15 @@ public class SalesforceOutputFormat extends OutputFormat<NullWritable, CSVRecord
       public void setupJob(JobContext jobContext) {
         Configuration conf = jobContext.getConfiguration();
         String sObjectName = conf.get(SalesforceSinkConstants.CONFIG_SOBJECT);
+        OperationEnum operationType = OperationEnum.valueOf(
+          conf.get(SalesforceSinkConstants.CONFIG_OPERATION).toLowerCase());
+        String externalIdField = conf.get(SalesforceSinkConstants.CONFIG_EXTERNAL_ID_FIELD);
 
         AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
 
         try {
           BulkConnection bulkConnection = new BulkConnection(Authenticator.createConnectorConfig(credentials));
-          JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectName, OperationEnum.insert);
+          JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectName, operationType, externalIdField);
           conf.set(SalesforceSinkConstants.CONFIG_JOB_ID, job.getId());
           LOG.info("Started Salesforce job with jobId='{}'", job.getId());
         } catch (AsyncApiException e) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormatProvider.java
@@ -33,17 +33,23 @@ public class SalesforceOutputFormatProvider implements OutputFormatProvider {
    * @param config Salesforce batch sink configuration
    */
   public SalesforceOutputFormatProvider(SalesforceSinkConfig config) {
-    this.configMap = new ImmutableMap.Builder<String, String>()
+    ImmutableMap.Builder<String, String> configBuilder = new ImmutableMap.Builder<String, String>()
       .put(SalesforceConstants.CONFIG_USERNAME, config.getUsername())
       .put(SalesforceConstants.CONFIG_PASSWORD, config.getPassword())
       .put(SalesforceConstants.CONFIG_CONSUMER_KEY, config.getConsumerKey())
       .put(SalesforceConstants.CONFIG_CONSUMER_SECRET, config.getConsumerSecret())
       .put(SalesforceConstants.CONFIG_LOGIN_URL, config.getLoginUrl())
       .put(SalesforceSinkConstants.CONFIG_SOBJECT, config.getSObject())
+      .put(SalesforceSinkConstants.CONFIG_OPERATION, config.getOperation())
       .put(SalesforceSinkConstants.CONFIG_ERROR_HANDLING, config.getErrorHandling().getValue())
       .put(SalesforceSinkConstants.CONFIG_MAX_BYTES_PER_BATCH, config.getMaxBytesPerBatch().toString())
-      .put(SalesforceSinkConstants.CONFIG_MAX_RECORDS_PER_BATCH, config.getMaxRecordsPerBatch().toString())
-      .build();
+      .put(SalesforceSinkConstants.CONFIG_MAX_RECORDS_PER_BATCH, config.getMaxRecordsPerBatch().toString());
+
+    if (config.getExternalIdField() != null) {
+      configBuilder.put(SalesforceSinkConstants.CONFIG_EXTERNAL_ID_FIELD, config.getExternalIdField());
+    }
+
+    this.configMap = configBuilder.build();
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConstants.java
@@ -20,6 +20,8 @@ package io.cdap.plugin.salesforce.plugin.sink.batch;
  */
 public class SalesforceSinkConstants {
   public static final String CONFIG_SOBJECT = "mapred.salesforce.sobject.name";
+  public static final String CONFIG_OPERATION = "mapred.salesforce.operation.type";
+  public static final String CONFIG_EXTERNAL_ID_FIELD = "mapred.salesforce.external.id";
   public static final String CONFIG_ERROR_HANDLING = "mapred.salesforce.error.handling";
   public static final String CONFIG_JOB_ID = "mapred.salesforce.job.id";
   public static final String CONFIG_MAX_BYTES_PER_BATCH = "mapred.salesforce.max.bytes.per.batch";

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
@@ -189,6 +189,7 @@ public abstract class BaseSalesforceBatchSinkETLTest extends BaseSalesforceETLTe
     Map<String, String> sinkProperties = new HashMap<>(getBaseProperties(REFERENCE_NAME)
       .put(SalesforceSinkConfig.PROPERTY_ERROR_HANDLING, "Stop on Error")
       .put(SalesforceSinkConfig.PROPERTY_SOBJECT, sObject)
+      .put(SalesforceSinkConfig.PROPERTY_OPERATION, "Insert")
       .put(SalesforceSinkConfig.PROPERTY_MAX_BYTES_PER_BATCH, "10000000")
       .put(SalesforceSinkConfig.PROPERTY_MAX_RECORDS_PER_BATCH, "10000")
       .build());
@@ -226,7 +227,7 @@ public abstract class BaseSalesforceBatchSinkETLTest extends BaseSalesforceETLTe
     return new SalesforceSinkConfig(REFERENCE_NAME,
                                     BaseSalesforceETLTest.CONSUMER_KEY, BaseSalesforceETLTest.CONSUMER_SECRET,
                                     BaseSalesforceETLTest.USERNAME, BaseSalesforceETLTest.PASSWORD,
-                                    BaseSalesforceETLTest.LOGIN_URL, sObject,
+                                    BaseSalesforceETLTest.LOGIN_URL, sObject, "Insert", null,
                                     "1000000", "10000", "Stop on Error");
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSinkETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSinkETLTest.java
@@ -105,6 +105,158 @@ public class SalesforceBatchSinkETLTest extends BaseSalesforceBatchSinkETLTest {
   }
 
   @Test
+  public void testUpdateAccount() throws Exception {
+    String sObject = "Account";
+    Schema schema = Schema.recordOf("output",
+                                    Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("NumberOfEmployees", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("ShippingLatitude", Schema.of(Schema.Type.DOUBLE)),
+                                    Schema.Field.of("ShippingLongitude", Schema.of(Schema.Type.DOUBLE))
+    );
+
+    List<StructuredRecord> inputRecords = ImmutableList.of(
+      StructuredRecord.builder(schema)
+        .set("Name", "testUpdateAccount1")
+        .set("NumberOfEmployees", 6)
+        .set("ShippingLatitude", 50.4501)
+        .set("ShippingLongitude", 30.5234)
+        .build(),
+      StructuredRecord.builder(schema)
+        .set("Name", "testUpdateAccount2")
+        .set("NumberOfEmployees", 1)
+        .set("ShippingLatitude", 37.4220)
+        .set("ShippingLongitude", 122.0841)
+        .build()
+    );
+    List<SObject> createdSObjects = new ArrayList<>();
+
+    ApplicationManager appManager = deployPipeline(sObject, schema);
+    runPipeline(appManager, inputRecords);
+    assertRecordsCreated(sObject, inputRecords, createdSObjects);
+    addToCleanUpList(createdSObjects);
+
+    schema = Schema.recordOf("output",
+                             Schema.Field.of("Id", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("NumberOfEmployees", Schema.of(Schema.Type.INT)),
+                             Schema.Field.of("ShippingLatitude", Schema.of(Schema.Type.DOUBLE)),
+                             Schema.Field.of("ShippingLongitude", Schema.of(Schema.Type.DOUBLE))
+    );
+
+    inputRecords = ImmutableList.of(
+      StructuredRecord.builder(schema)
+        .set("Id", createdObjectsIds.get(0))
+        .set("Name", "testUpdateAccount1Stage2")
+        .set("NumberOfEmployees", 6)
+        .set("ShippingLatitude", 50.4501)
+        .set("ShippingLongitude", 30.5234)
+        .build(),
+      StructuredRecord.builder(schema)
+        .set("Id", createdObjectsIds.get(1))
+        .set("Name", "testUpdateAccount2Stage2")
+        .set("NumberOfEmployees", 1)
+        .set("ShippingLatitude", 37.4220)
+        .set("ShippingLongitude", 122.0841)
+        .build()
+    );
+
+    Map<String, String> sinkProperties = new ImmutableMap.Builder<String, String>()
+      .put(SalesforceSinkConfig.PROPERTY_OPERATION, "Update")
+      .build();
+
+    appManager = deployPipeline(sObject, schema, sinkProperties);
+    runPipeline(appManager, inputRecords);
+    assertRecordsCreated(sObject, inputRecords, createdSObjects);
+    addToCleanUpList(createdSObjects);
+  }
+
+  @Test
+  public void testUpsertOpportunity() throws Exception {
+    String sObject = "Opportunity";
+    Schema schema = Schema.recordOf("output",
+                                    Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("StageName", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("CloseDate", Schema.of(Schema.LogicalType.DATE)),
+                                    Schema.Field.of("StageName", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of("IsPrivate", Schema.of(Schema.Type.BOOLEAN)),
+                                    Schema.Field.of("Amount", Schema.of(Schema.Type.DOUBLE)),
+                                    Schema.Field.of("ForecastCategoryName", Schema.of(Schema.Type.STRING))
+    );
+
+    List<StructuredRecord> inputRecords1 = ImmutableList.of(
+      StructuredRecord.builder(schema)
+        .set("Name", "testUpsertOpportunity1")
+        .set("StageName", "Prospecting")
+        .set("CloseDate", 17897).set("IsPrivate", true)
+        .set("Amount", 123.0)
+        .set("ForecastCategoryName", "Omitted")
+        .build(),
+      StructuredRecord.builder(schema)
+        .set("Name", "testUpsertOpportunity2")
+        .set("StageName", "Closed Won")
+        .set("CloseDate", 17897)
+        .set("IsPrivate", false)
+        .set("Amount", 0.0)
+        .set("ForecastCategoryName", "Closed")
+        .build()
+    );
+    List<SObject> createdSObjects = new ArrayList<>();
+
+    ApplicationManager appManager = deployPipeline(sObject, schema);
+    runPipeline(appManager, inputRecords1);
+    assertRecordsCreated(sObject, inputRecords1, createdSObjects);
+    addToCleanUpList(createdSObjects);
+
+    schema = Schema.recordOf("output",
+                             Schema.Field.of("Id", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("StageName", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("CloseDate", Schema.of(Schema.LogicalType.DATE)),
+                             Schema.Field.of("StageName", Schema.of(Schema.Type.STRING)),
+                             Schema.Field.of("IsPrivate", Schema.of(Schema.Type.BOOLEAN)),
+                             Schema.Field.of("Amount", Schema.of(Schema.Type.DOUBLE)),
+                             Schema.Field.of("ForecastCategoryName", Schema.of(Schema.Type.STRING))
+    );
+
+    List<StructuredRecord> inputRecords2 = ImmutableList.of(
+      StructuredRecord.builder(schema)
+        .set("Id", createdObjectsIds.get(0))
+        .set("Name", "testUpsertOpportunity1Stage2")
+        .set("StageName", "Prospecting")
+        .set("CloseDate", 17897)
+        .set("IsPrivate", true)
+        .set("Amount", 123.0)
+        .set("ForecastCategoryName", "Omitted")
+        .build(),
+      StructuredRecord.builder(schema)
+        .set("Id", "")
+        .set("Name", "testUpsertOpportunity2Stage2")
+        .set("StageName", "Closed Won")
+        .set("CloseDate", 17897)
+        .set("IsPrivate", false)
+        .set("Amount", 0.0)
+        .set("ForecastCategoryName", "Closed")
+        .build()
+    );
+    createdSObjects = new ArrayList<>();
+
+    Map<String, String> sinkProperties = new ImmutableMap.Builder<String, String>()
+      .put(SalesforceSinkConfig.PROPERTY_OPERATION, "Upsert")
+      .put(SalesforceSinkConfig.PROPERTY_EXTERNAL_ID_FIELD, "Id")
+      .build();
+
+    appManager = deployPipeline(sObject, schema, sinkProperties);
+    runPipeline(appManager, inputRecords2);
+
+    List<StructuredRecord> expectedRecords = new ArrayList<>();
+    expectedRecords.add(inputRecords1.get(1));
+    expectedRecords.addAll(inputRecords2);
+
+    assertRecordsCreated(sObject, expectedRecords, createdSObjects);
+    addToCleanUpList(createdSObjects);
+  }
+
+  @Test
   public void testNonDefaultFieldsCase() throws Exception {
     String sObject = "Account";
     Schema schema = Schema.recordOf("output",

--- a/widgets/Salesforce-batchsink.json
+++ b/widgets/Salesforce-batchsink.json
@@ -55,8 +55,36 @@
           "name": "sObject"
         },
         {
+          "widget-type": "radio-group",
+          "label": "Operation",
+          "name": "operation",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "Insert",
+            "options": [
+              {
+                "id": "insert",
+                "label": "Insert"
+              },
+              {
+                "id": "upsert",
+                "label": "Upsert"
+              },
+              {
+                "id": "update",
+                "label": "Update"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
-          "label": "Max records per batch",
+          "label": "Upsert External ID Field",
+          "name": "externalIdField"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max Records Per Batch",
           "name": "maxRecordsPerBatch",
           "widget-attributes" : {
             "default": "10000"
@@ -64,7 +92,7 @@
         },
         {
           "widget-type": "textbox",
-          "label": "Max bytes per batch",
+          "label": "Max Bytes Per Batch",
           "name": "maxBytesPerBatch",
           "widget-attributes" : {
             "default": "10000000"


### PR DESCRIPTION
Without the change only insert is supported.

_How new operations work in Salesforce:_
**Upsert** - Salesforce requires user to provide an external id field name. This field is used as basis for upsert (Salesforce will decide if objects are the same using it).

Id field can be used for that (which is present for all Salesforce sObjects). Also user can create a custom field and checkmark it as "External Id" via Salesforce UI.

**Update** - Specifying an external id field is not supported. For updates Salesforce will always use 'Id' field as basis.