### PR TITLE
 CDAP-15492 Salesforce streaming integration tests fail, jar includes unnecessary Spark

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Instructions to run the tests:
  3. Run the tests using the command below:
 
 ```
-mvn clean test -Dsalesforce.test.consumerKey= -Dsalesforce.test.consumerSecret= -Dsalesforce.test.username= -Dsalesforce.test.password=
+mvn clean test -Dsalesforce.test.consumerKey= -Dsalesforce.test.consumerSecret= -Dsalesforce.test.username= -Dsalesforce.test.password= -Djackson2.version=2.6.7
 ```
 
 # Contact

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
       <version>${spark2.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/widgets/Salesforce-batchsink.json
+++ b/widgets/Salesforce-batchsink.json
@@ -60,7 +60,7 @@
           "name": "operation",
           "widget-attributes": {
             "layout": "inline",
-            "default": "Insert",
+            "default": "insert",
             "options": [
               {
                 "id": "insert",


### PR DESCRIPTION
1. Streaming integration tests fail with:
```
testValuesReturned(io.cdap.plugin.salesforce.etl.SalesforceStreamingSourceETLTest)  Time elapsed: 5.255 sec  <<< ERROR!
 java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.lang.ExceptionInInitializerError
     at com.fasterxml.jackson.module.scala.JacksonModule$class.setupModule(JacksonModule.scala:64)
     at com.fasterxml.jackson.module.scala.DefaultScalaModule.setupModule(DefaultScalaModule.scala:19)
     at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:751)
     at org.apache.spark.rdd.RDDOperationScope$.<init>(RDDOperationScope.scala:82)
     at org.apache.spark.rdd.RDDOperationScope$.<clinit>(RDDOperationScope.scala)
     at org.apache.spark.streaming.StreamingContext.withNamedScope(StreamingContext.scala:273)
     at org.apache.spark.streaming.StreamingContext.receiverStream(StreamingContext.scala:282)
     at org.apache.spark.streaming.api.java.JavaStreamingContext.receiverStream(JavaStreamingContext.scala:428)
     at io.cdap.plugin.salesforce.plugin.source.streaming.SalesforceStreamingSource.getStream(SalesforceStreamingSource.java:115)
     at io.cdap.cdap.etl.spark.plugin.WrappedStreamingSource$2.call(WrappedStreamingSource.java:59)
     ...
```
This happens because com.fasterxml.jackson.core/jackson-databind 2.6.7 is used by org.apache.spark/spark-core_2.11. While with the patch we use 2.9.9.
So I guess when we classload all the classes into a single scope wrong jackson-databind gets loaded, causing spark to fail.
2. Salesforce jar has size of 32Mb currently. Without spark core which is provided by CDAP, therefore unnecessary, it has size of 9Mb.
3. Fix a wrong default value for SFDC widget causing "unknown value" problems. 