### PR TITLE
Added support for defining parent object for PK chunking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <name>Salesforce plugins</name>
   <groupId>io.cdap.plugin</groupId>
   <artifactId>salesforce-plugins</artifactId>
-  <version>1.3.3</version>
+  <version>1.3.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
@@ -68,7 +68,8 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
       .put(SalesforceSourceConstants.CONFIG_QUERIES, GSON.toJson(queries))
       .put(SalesforceSourceConstants.CONFIG_SCHEMAS, GSON.toJson(schemas))
       .put(SalesforceSourceConstants.CONFIG_PK_CHUNK_ENABLE, String.valueOf(config.getEnablePKChunk()))
-      .put(SalesforceSourceConstants.CONFIG_CHUNK_SIZE, String.valueOf(config.getChunkSize()));
+      .put(SalesforceSourceConstants.CONFIG_CHUNK_SIZE, String.valueOf(config.getChunkSize()))
+      .put(SalesforceSourceConstants.CONFIG_CHUNK_PARENT, config.getParent());
 
     if (sObjectNameField != null) {
       builder.put(SalesforceSourceConstants.CONFIG_SOBJECT_NAME_FIELD, sObjectNameField);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -45,8 +45,8 @@ import javax.annotation.Nullable;
 import static io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants.SUPPORTED_OBJECTS_WITH_PK_CHUNK;
 
 /**
- * This class {@link SalesforceSourceConfig} provides all the configuration required for
- * configuring the {@link SalesforceBatchSource} plugin.
+ * This class {@link SalesforceSourceConfig} provides all the configuration required for configuring the {@link
+ * SalesforceBatchSource} plugin.
  */
 public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
 
@@ -81,6 +81,12 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   @Description("Specify size of chunk. Maximum Size is 250,000. Default Size is 100,000.")
   private Integer chunkSize;
 
+  @Name(SalesforceSourceConstants.PROPERTY_PARENT_NAME)
+  @Macro
+  @Nullable
+  @Description("Parent of the Salesforce Object. This is used to enable chunking for history tables or shared objects.")
+  private String parent;
+
   @VisibleForTesting
   SalesforceSourceConfig(String referenceName,
                          @Nullable String consumerKey,
@@ -97,7 +103,8 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
                          @Nullable String schema,
                          @Nullable String securityToken,
                          @Nullable Boolean enablePKChunk,
-                         @Nullable Integer chunkSize) {
+                         @Nullable Integer chunkSize,
+                         @Nullable String parent) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
           datetimeAfter, datetimeBefore, duration, offset, securityToken);
     this.query = query;
@@ -105,11 +112,12 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
     this.schema = schema;
     this.enablePKChunk = enablePKChunk;
     this.chunkSize = chunkSize;
+    this.parent = parent;
   }
 
   /**
-   * Returns SOQL to retrieve data from Salesforce. If user has provided SOQL, returns given SOQL.
-   * If user has provided sObject name, generates SOQL based on sObject metadata and provided filters.
+   * Returns SOQL to retrieve data from Salesforce. If user has provided SOQL, returns given SOQL. If user has provided
+   * sObject name, generates SOQL based on sObject metadata and provided filters.
    *
    * @param logicalStartTime application start time
    * @return SOQL query
@@ -125,12 +133,17 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   }
 
   @Nullable
+  public String getParent() {
+    return parent;
+  }
+
+  @Nullable
   public Schema getSchema() {
     try {
       return Strings.isNullOrEmpty(schema) ? null : Schema.parseJson(schema);
     } catch (IOException e) {
       throw new InvalidConfigException("Unable to parse output schema: " +
-        schema, e, SalesforceSourceConstants.PROPERTY_SCHEMA);
+                                         schema, e, SalesforceSourceConstants.PROPERTY_SCHEMA);
     }
   }
 
@@ -141,7 +154,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
       return false;
     }
     throw new InvalidConfigException("SOQL query or SObject name must be provided",
-                                             SalesforceSourceConstants.PROPERTY_QUERY);
+                                     SalesforceSourceConstants.PROPERTY_QUERY);
   }
 
   @Override
@@ -227,7 +240,8 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
 
   private void validatePKChunk(FailureCollector collector) {
     if (containsMacro(SalesforceSourceConstants.PROPERTY_PK_CHUNK_ENABLE_NAME)
-      || containsMacro(SalesforceSourceConstants.PROPERTY_CHUNK_SIZE_NAME)) {
+      || containsMacro(SalesforceSourceConstants.PROPERTY_CHUNK_SIZE_NAME)
+      || containsMacro(SalesforceSourceConstants.PROPERTY_PARENT_NAME)) {
       return;
     }
 
@@ -237,19 +251,29 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
 
     if (!containsMacro(SalesforceSourceConstants.PROPERTY_QUERY) && !Strings.isNullOrEmpty(query)) {
       if (SalesforceQueryParser.isRestrictedPKQuery(query)) {
-          collector.addFailure(
-            String.format("SOQL Query contains restricted clauses when PK Chunk is Enabled. Unsupported query: '%s'.",
-                          query),
-            "Set Enable PK Chunk to false, because 'WHERE' is the only supported conditions clause.")
-            .withConfigProperty(SalesforceSourceConstants.PROPERTY_QUERY);
-        }
+        collector.addFailure(
+          String.format("SOQL Query contains restricted clauses when PK Chunk is Enabled. Unsupported query: '%s'.",
+                        query),
+          "Set Enable PK Chunk to false, because 'WHERE' is the only supported conditions clause.")
+          .withConfigProperty(SalesforceSourceConstants.PROPERTY_QUERY);
+      }
 
-      String sObject = SalesforceQueryParser.getObjectDescriptorFromQuery(query).getName();
-      checkForPKSupportedObject(sObject, collector);
+      // If a parent object is defined then use that to check for PK support, otherwise use the object from the query
+      if (!containsMacro(SalesforceSourceConstants.PROPERTY_PARENT_NAME) && !Strings.isNullOrEmpty(getParent())) {
+        checkForPKSupportedObject(getParent(), collector);
+      } else {
+        String sObject = SalesforceQueryParser.getObjectDescriptorFromQuery(query).getName();
+        checkForPKSupportedObject(sObject, collector);
+      }
     }
 
+    // If a parent object is defined then use that to check for PK support, otherwise use the object from the config
     if (!containsMacro(SalesforceSourceConstants.PROPERTY_SOBJECT_NAME) && !Strings.isNullOrEmpty(getSObjectName())) {
-      checkForPKSupportedObject(getSObjectName(), collector);
+      if (!containsMacro(SalesforceSourceConstants.PROPERTY_PARENT_NAME) && !Strings.isNullOrEmpty(getParent())) {
+        checkForPKSupportedObject(getParent(), collector);
+      } else {
+        checkForPKSupportedObject(getSObjectName(), collector);
+      }
     }
 
     if (getChunkSize() > SalesforceSourceConstants.MAX_PK_CHUNK_SIZE) {
@@ -273,8 +297,9 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
     if (canAttemptToEstablishConnection()) {
       if (!isCustomObject(sObject, collector)) {
         if (!SUPPORTED_OBJECTS_WITH_PK_CHUNK.contains(sObject)) {
-          collector.addFailure(String.format("SObject: %s is not supported with PKChunk enabled.", sObject),
-                               "Please check documentation for supported Objects.");
+          collector.addFailure(String.format("SObject '%s' is not supported with PKChunk enabled.", sObject),
+                               "Please check documentation for supported Objects. If this is a history " +
+                                 "or shared table, you may need to specify a SObject Parent in the Advanced section.");
         }
       }
     }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -34,6 +34,7 @@ public class SalesforceSourceConstants {
 
   public static final String PROPERTY_PK_CHUNK_ENABLE_NAME = "enablePKChunk";
   public static final String PROPERTY_CHUNK_SIZE_NAME = "chunkSize";
+  public static final String PROPERTY_PARENT_NAME = "parent";
 
   public static final String PROPERTY_WHITE_LIST = "whiteList";
   public static final String PROPERTY_BLACK_LIST = "blackList";
@@ -44,8 +45,10 @@ public class SalesforceSourceConstants {
 
   public static final String CONFIG_PK_CHUNK_ENABLE = "mapred.salesforce.input.pk.chunk";
   public static final String CONFIG_CHUNK_SIZE = "mapred.salesforce.input.schemas.chunk.size";
+  public static final String CONFIG_CHUNK_PARENT = "mapred.salesforce.input.schemas.chunk.parent";
   public static final String HEADER_ENABLE_PK_CHUNK = "Sforce-Enable-PKChunking";
   public static final String HEADER_VALUE_PK_CHUNK = "chunkSize=%d";
+  public static final String HEADER_PK_CHUNK_PARENT = "parent=%s";
 
   public static final String CONFIG_SOBJECT_NAME_FIELD = "mapred.salesforce.input.sObjectNameField";
 

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -36,6 +36,7 @@ public class SalesforceSourceConfigBuilder {
   private String securityToken;
   private Boolean enablePKChunk;
   private Integer chunkSize;
+  private String parent;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -117,9 +118,14 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
+  public SalesforceSourceConfigBuilder setParent(String parent) {
+    this.parent = parent;
+    return this;
+  }
+
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                       query, sObjectName, datetimeAfter, datetimeBefore, duration, offset, schema,
-                                      securityToken, enablePKChunk, chunkSize);
+                                      securityToken, enablePKChunk, chunkSize, parent);
   }
 }

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -163,6 +163,14 @@
           "widget-attributes" : {
             "placeholder": "100000"
           }
+        },
+        {
+          "name": "parent",
+          "label" : "SObject Parent Name",
+          "widget-type": "textbox",
+          "widget-attributes" : {
+            "placeholder": "Salesforce object parent name"
+          }
         }
       ]
     }
@@ -176,6 +184,9 @@
       "show": [
         {
           "name": "chunkSize"
+        },
+        {
+          "name": "parent"
         }
       ]
     }


### PR DESCRIPTION
The Salesforce [chunking option](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/async_api_headers_enable_pk_chunking.htm) supports an additional "parent" header that can be used to define a parent object that can be used for chunking. This is used when the object being fetched is a history table or a shared object. 