### PR TITLE
Added support for defining parent object for PK chunking

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
@@ -79,7 +79,8 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
       .put(SalesforceSourceConstants.CONFIG_QUERIES, GSON.toJson(queries))
       .put(SalesforceSourceConstants.CONFIG_SCHEMAS, GSON.toJson(schemas))
       .put(SalesforceSourceConstants.CONFIG_PK_CHUNK_ENABLE, String.valueOf(config.getEnablePKChunk()))
-      .put(SalesforceSourceConstants.CONFIG_CHUNK_SIZE, String.valueOf(config.getChunkSize()));
+      .put(SalesforceSourceConstants.CONFIG_CHUNK_SIZE, String.valueOf(config.getChunkSize()))
+      .put(SalesforceSourceConstants.CONFIG_CHUNK_PARENT, config.getParent());
 
     if (sObjectNameField != null) {
       builder.put(SalesforceSourceConstants.CONFIG_SOBJECT_NAME_FIELD, sObjectNameField);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -34,6 +34,7 @@ public class SalesforceSourceConstants {
 
   public static final String PROPERTY_PK_CHUNK_ENABLE_NAME = "enablePKChunk";
   public static final String PROPERTY_CHUNK_SIZE_NAME = "chunkSize";
+  public static final String PROPERTY_PARENT_NAME = "parent";
 
   public static final String PROPERTY_WHITE_LIST = "whiteList";
   public static final String PROPERTY_BLACK_LIST = "blackList";
@@ -44,8 +45,10 @@ public class SalesforceSourceConstants {
 
   public static final String CONFIG_PK_CHUNK_ENABLE = "mapred.salesforce.input.pk.chunk";
   public static final String CONFIG_CHUNK_SIZE = "mapred.salesforce.input.schemas.chunk.size";
+  public static final String CONFIG_CHUNK_PARENT = "mapred.salesforce.input.schemas.chunk.parent";
   public static final String HEADER_ENABLE_PK_CHUNK = "Sforce-Enable-PKChunking";
   public static final String HEADER_VALUE_PK_CHUNK = "chunkSize=%d";
+  public static final String HEADER_PK_CHUNK_PARENT = "parent=%s";
 
   public static final String CONFIG_SOBJECT_NAME_FIELD = "mapred.salesforce.input.sObjectNameField";
 

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -36,6 +36,7 @@ public class SalesforceSourceConfigBuilder {
   private String securityToken;
   private Boolean enablePKChunk;
   private Integer chunkSize;
+  private String parent;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -117,9 +118,14 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
+  public SalesforceSourceConfigBuilder setParent(String parent) {
+    this.parent = parent;
+    return this;
+  }
+
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                       query, sObjectName, datetimeAfter, datetimeBefore, duration, offset, schema,
-                                      securityToken, null, enablePKChunk, chunkSize);
+                                      securityToken, null, enablePKChunk, chunkSize, parent);
   }
 }

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -168,6 +168,14 @@
           "widget-attributes" : {
             "placeholder": "100000"
           }
+        },
+        {
+          "name": "parent",
+          "label" : "SObject Parent Name",
+          "widget-type": "textbox",
+          "widget-attributes" : {
+            "placeholder": "Salesforce object parent name"
+          }
         }
       ]
     }
@@ -181,6 +189,9 @@
       "show": [
         {
           "name": "chunkSize"
+        },
+        {
+          "name": "parent"
         }
       ]
     }


### PR DESCRIPTION
cherrypick of #72 

The Salesforce [chunking option](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/async_api_headers_enable_pk_chunking.htm) supports an additional "parent" header that can be used to define a parent object that can be used for chunking. This is used when the object being fetched is a history table or a shared object. 