### PR TITLE
(PLUGIN-711) Close the bulk job when closing record reader

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
@@ -17,12 +17,17 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.sforce.async.AsyncApiException;
+import com.sforce.async.BatchInfo;
+import com.sforce.async.BatchStateEnum;
 import com.sforce.async.BulkConnection;
+import com.sforce.async.QueryResultList;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.salesforce.BulkAPIBatchException;
 import io.cdap.plugin.salesforce.SalesforceBulkUtil;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -36,8 +41,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -81,7 +90,7 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     try {
       AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
       bulkConnection = new BulkConnection(Authenticator.createConnectorConfig(credentials));
-      InputStream queryResponseStream = SalesforceBulkUtil.waitForBatchResults(bulkConnection, jobId, batchId);
+      InputStream queryResponseStream = waitForBatchResults(bulkConnection, jobId, batchId);
       setupParser(queryResponseStream);
     } catch (AsyncApiException e) {
       throw new RuntimeException("There was issue communicating with Salesforce", e);
@@ -145,5 +154,44 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     }
 
     parserIterator = csvParser.iterator();
+  }
+
+  /**
+   * Wait until a batch with given batchId succeeds, or throw an exception
+   *
+   * @param bulkConnection bulk connection instance
+   * @param jobId a job id
+   * @param batchId a batch id
+   * @return an input stream which represents a current batch response, which is a bunch of lines in csv format.
+   *
+   * @throws AsyncApiException  if there is an issue creating the job
+   * @throws InterruptedException sleep interrupted
+   */
+  public InputStream waitForBatchResults(BulkConnection bulkConnection, String jobId, String batchId)
+    throws AsyncApiException, InterruptedException {
+
+    BatchInfo info = null;
+    for (int i = 0; i < SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES; i++) {
+      info = bulkConnection.getBatchInfo(jobId, batchId);
+
+      if (info.getState() == BatchStateEnum.Completed) {
+        QueryResultList list =
+          bulkConnection.getQueryResultList(jobId, batchId);
+        String[] resultIds = list.getResult();
+
+        List<InputStream> streams = new ArrayList<>(resultIds.length);
+        for (String resultId : resultIds) {
+          streams.add(bulkConnection.getQueryResultStream(jobId, batchId, resultId));
+        }
+
+        return new SequenceInputStream(Collections.enumeration(streams));
+      } else if (info.getState() == BatchStateEnum.Failed) {
+
+        throw new BulkAPIBatchException("Batch failed", info);
+      } else {
+        Thread.sleep(SalesforceSourceConstants.GET_BATCH_RESULTS_SLEEP_MS);
+      }
+    }
+    throw new BulkAPIBatchException("Timeout waiting for batch results", info);
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -126,4 +126,17 @@ public class SalesforceSourceConstants {
                                                                                    "VoiceCall",
                                                                                    "WorkOrder",
                                                                                    "WorkOrderLineItem");
+
+  /**
+   * Salesforce Bulk API has a limitation, which is 10 minutes per processing of a batch
+   */
+  public static final long GET_BATCH_WAIT_TIME_SECONDS = 600;
+  /**
+   * Sleep time between polling the batch status
+   */
+  public static final long GET_BATCH_RESULTS_SLEEP_MS = 500;
+  /**
+   * Number of tries while polling the batch status
+   */
+  public static final long GET_BATCH_RESULTS_TRIES = GET_BATCH_WAIT_TIME_SECONDS * (1000 / GET_BATCH_RESULTS_SLEEP_MS);
 }


### PR DESCRIPTION
First commit is the fix.

Second commit is just cleanup common static code that was not really "common"