### PR TITLE
Cherrypick fixes from release/1.3

### DIFF
--- a/docs/Salesforce-batchsource.md
+++ b/docs/Salesforce-batchsource.md
@@ -163,6 +163,9 @@ Primary key (PK) Chunking splits query on large tables into chunks based on the 
 
 Salesforce recommends that you enable PK chunking when querying tables with more than 10 million records or when a bulk query consistently times out. 
 However, the effectiveness of PK chunking depends on the specifics of the query and the queried data.
+We do not recommend enabling PK chunking when querying a large table and filtering out most of the data.
+A separate query is created for each chunk, so enabling PK chunking on a large table can end up counting as
+thousands of queries against the quota.
 
 For example, let’s say you enable PK chunking for the following query on an Account table with 10,000,000 records.
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <salesforce.api.version>45.0.0</salesforce.api.version>
     <cometd.java.client.version>4.0.0</cometd.java.client.version>
     <antlr.version>4.7.2</antlr.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.23.0</mockito.version>
     <commons.csv.version>1.6</commons.csv.version>
     <jackson.version>1.9.13</jackson.version>
     <jackson2.version>2.9.9</jackson2.version>
@@ -350,7 +350,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
@@ -27,18 +27,12 @@ import com.sforce.async.ContentType;
 import com.sforce.async.JobInfo;
 import com.sforce.async.JobStateEnum;
 import com.sforce.async.OperationEnum;
-import com.sforce.async.QueryResultList;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.SequenceInputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,19 +45,6 @@ import java.util.stream.Collectors;
  */
 public final class SalesforceBulkUtil {
   private static final Logger LOG = LoggerFactory.getLogger(SalesforceBulkUtil.class);
-
-  /**
-   * Salesforce Bulk API has a limitation, which is 10 minutes per processing of a batch
-   */
-  private static final long GET_BATCH_WAIT_TIME_SECONDS = 600;
-  /**
-   * Sleep time between polling the batch status
-   */
-  private static final long GET_BATCH_RESULTS_SLEEP_MS = 500;
-  /**
-   * Number of tries while polling the batch status
-   */
-  private static final long GET_BATCH_RESULTS_TRIES = GET_BATCH_WAIT_TIME_SECONDS * (1000 / GET_BATCH_RESULTS_SLEEP_MS);
 
 
   /**
@@ -102,106 +83,6 @@ public final class SalesforceBulkUtil {
     job.setId(jobId);
     job.setState(JobStateEnum.Closed);
     bulkConnection.updateJob(job);
-  }
-
-
-  /**
-   * Start batch job of reading a given guery result.
-   *
-   * @param bulkConnection bulk connection instance
-   * @param query a SOQL query
-   * @param enablePKChunk enable PK Chunk
-   * @return an array of batches
-   * @throws AsyncApiException  if there is an issue creating the job
-   * @throws IOException failed to close the query
-   */
-  public static BatchInfo[] runBulkQuery(BulkConnection bulkConnection, String query, boolean enablePKChunk)
-    throws AsyncApiException, IOException {
-
-    SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
-    JobInfo job = createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.query, null);
-    BatchInfo batchInfo;
-    try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
-      batchInfo = bulkConnection.createBatchFromStream(job, bout);
-    }
-    return enablePKChunk ? waitForBatchChunks(bulkConnection, job.getId(), batchInfo.getId()) :
-      bulkConnection.getBatchInfoList(job.getId()).getBatchInfo();
-  }
-
-  /** When PK Chunk is enabled, wait for state of initial batch to be NotProcessed, in this case Salesforce API will
-   * decide how many batches will be created
-   * @param bulkConnection bulk connection instance
-   * @param jobId a job id
-   * @param initialBatchId a batch id
-   * @return Array with Batches created by Salesforce API
-   *
-   * @throws AsyncApiException if there is an issue creating the job
-   */
-  private static BatchInfo[] waitForBatchChunks(BulkConnection bulkConnection, String jobId, String initialBatchId)
-    throws AsyncApiException {
-    BatchInfo initialBatchInfo = null;
-    for (int i = 0; i < GET_BATCH_RESULTS_TRIES; i++) {
-      //check if the job is aborted
-      if (bulkConnection.getJobStatus(jobId).getState() == JobStateEnum.Aborted) {
-        LOG.info(String.format("Job with Id: '%s' is aborted", jobId));
-        return new BatchInfo[0];
-      }
-      initialBatchInfo = bulkConnection.getBatchInfo(jobId, initialBatchId);
-
-      if (initialBatchInfo.getState() == BatchStateEnum.NotProcessed) {
-        BatchInfo[] result = bulkConnection.getBatchInfoList(jobId).getBatchInfo();
-        return Arrays.stream(result).filter(batchInfo -> batchInfo.getState() != BatchStateEnum.NotProcessed)
-          .toArray(BatchInfo[]::new);
-      } else if (initialBatchInfo.getState() == BatchStateEnum.Failed) {
-        throw new BulkAPIBatchException("Batch failed", initialBatchInfo);
-      } else {
-        try {
-          Thread.sleep(GET_BATCH_RESULTS_SLEEP_MS);
-        } catch (InterruptedException e) {
-          throw new RuntimeException("Job is aborted", e);
-        }
-      }
-    }
-    throw new BulkAPIBatchException("Timeout waiting for batch results", initialBatchInfo);
-  }
-
-  /**
-   * Wait until a batch with given batchId succeeds, or throw an exception
-   *
-   * @param bulkConnection bulk connection instance
-   * @param jobId a job id
-   * @param batchId a batch id
-   * @return an input stream which represents a current batch response, which is a bunch of lines in csv format.
-   *
-   * @throws AsyncApiException  if there is an issue creating the job
-   * @throws InterruptedException sleep interrupted
-   */
-  public static InputStream waitForBatchResults(BulkConnection bulkConnection, String jobId, String batchId)
-    throws AsyncApiException, InterruptedException {
-
-    BatchInfo info = null;
-    for (int i = 0; i < GET_BATCH_RESULTS_TRIES; i++) {
-      info = bulkConnection.getBatchInfo(jobId, batchId);
-
-      if (info.getState() == BatchStateEnum.Completed) {
-        QueryResultList list =
-          bulkConnection.getQueryResultList(jobId, batchId);
-        String[] resultIds = list.getResult();
-
-        List<InputStream> streams = new ArrayList<>(resultIds.length);
-        for (String resultId : resultIds) {
-          streams.add(bulkConnection.getQueryResultStream(jobId, batchId, resultId));
-        }
-
-        return new SequenceInputStream(Collections.enumeration(streams));
-      } else if (info.getState() == BatchStateEnum.Failed) {
-
-        throw new BulkAPIBatchException("Batch failed", info);
-      } else {
-        Thread.sleep(GET_BATCH_RESULTS_SLEEP_MS);
-      }
-    }
-    throw new BulkAPIBatchException("Timeout waiting for batch results", info);
   }
 
   /**
@@ -263,8 +144,8 @@ public final class SalesforceBulkUtil {
       .collect(Collectors.toSet());
 
     Awaitility.await()
-      .atMost(GET_BATCH_WAIT_TIME_SECONDS, TimeUnit.SECONDS)
-      .pollInterval(GET_BATCH_RESULTS_SLEEP_MS, TimeUnit.MILLISECONDS)
+      .atMost(SalesforceSourceConstants.GET_BATCH_WAIT_TIME_SECONDS, TimeUnit.SECONDS)
+      .pollInterval(SalesforceSourceConstants.GET_BATCH_RESULTS_SLEEP_MS, TimeUnit.MILLISECONDS)
       .until(() -> {
         BatchInfo[] statusList =
           bulkConnection.getBatchInfoList(job.getId()).getBatchInfo();

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
@@ -17,12 +17,17 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.sforce.async.AsyncApiException;
+import com.sforce.async.BatchInfo;
+import com.sforce.async.BatchStateEnum;
 import com.sforce.async.BulkConnection;
+import com.sforce.async.QueryResultList;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.salesforce.BulkAPIBatchException;
 import io.cdap.plugin.salesforce.SalesforceBulkUtil;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -36,8 +41,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -81,7 +90,7 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     try {
       AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
       bulkConnection = new BulkConnection(Authenticator.createConnectorConfig(credentials));
-      InputStream queryResponseStream = SalesforceBulkUtil.waitForBatchResults(bulkConnection, jobId, batchId);
+      InputStream queryResponseStream = waitForBatchResults(bulkConnection, jobId, batchId);
       setupParser(queryResponseStream);
     } catch (AsyncApiException e) {
       throw new RuntimeException("There was issue communicating with Salesforce", e);
@@ -147,5 +156,44 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     }
 
     parserIterator = csvParser.iterator();
+  }
+
+  /**
+   * Wait until a batch with given batchId succeeds, or throw an exception
+   *
+   * @param bulkConnection bulk connection instance
+   * @param jobId a job id
+   * @param batchId a batch id
+   * @return an input stream which represents a current batch response, which is a bunch of lines in csv format.
+   *
+   * @throws AsyncApiException  if there is an issue creating the job
+   * @throws InterruptedException sleep interrupted
+   */
+  public InputStream waitForBatchResults(BulkConnection bulkConnection, String jobId, String batchId)
+    throws AsyncApiException, InterruptedException {
+
+    BatchInfo info = null;
+    for (int i = 0; i < SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES; i++) {
+      info = bulkConnection.getBatchInfo(jobId, batchId);
+
+      if (info.getState() == BatchStateEnum.Completed) {
+        QueryResultList list =
+          bulkConnection.getQueryResultList(jobId, batchId);
+        String[] resultIds = list.getResult();
+
+        List<InputStream> streams = new ArrayList<>(resultIds.length);
+        for (String resultId : resultIds) {
+          streams.add(bulkConnection.getQueryResultStream(jobId, batchId, resultId));
+        }
+
+        return new SequenceInputStream(Collections.enumeration(streams));
+      } else if (info.getState() == BatchStateEnum.Failed) {
+
+        throw new BulkAPIBatchException("Batch failed", info);
+      } else {
+        Thread.sleep(SalesforceSourceConstants.GET_BATCH_RESULTS_SLEEP_MS);
+      }
+    }
+    throw new BulkAPIBatchException("Timeout waiting for batch results", info);
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
@@ -124,10 +124,12 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
       // this also closes the inputStream
       csvParser.close();
     }
-    try {
-      SalesforceBulkUtil.closeJob(bulkConnection, jobId);
-    } catch (AsyncApiException e) {
-      throw new IOException(e);
+    if (bulkConnection != null) {
+      try {
+        SalesforceBulkUtil.closeJob(bulkConnection, jobId);
+      } catch (AsyncApiException e) {
+        throw new IOException(e);
+      }
     }
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -126,4 +126,17 @@ public class SalesforceSourceConstants {
                                                                                    "VoiceCall",
                                                                                    "WorkOrder",
                                                                                    "WorkOrderLineItem");
+
+  /**
+   * Salesforce Bulk API has a limitation, which is 10 minutes per processing of a batch
+   */
+  public static final long GET_BATCH_WAIT_TIME_SECONDS = 600;
+  /**
+   * Sleep time between polling the batch status
+   */
+  public static final long GET_BATCH_RESULTS_SLEEP_MS = 500;
+  /**
+   * Number of tries while polling the batch status
+   */
+  public static final long GET_BATCH_RESULTS_TRIES = GET_BATCH_WAIT_TIME_SECONDS * (1000 / GET_BATCH_RESULTS_SLEEP_MS);
 }

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
@@ -39,10 +39,9 @@ public class SalesforceBulkRecordReaderTest {
   public void testMultipleResults() throws Exception {
     String csvString1 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
       "\"0061i000003XNcBAAW\",\"false\",\"1500.0\",\"2019-02-22T07:03:21.000Z\",\"2019-01-01\",\"12:00:30.000Z\"\n";
-    String csvString2 =
+    String csvString2 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
       "\"0061i000003XNcCAAW\",\"false\",\"112500.0\",\"2019-02-22T07:03:21.000Z\",\"2018-12-20\",\"12:00:40.000Z\"\n" +
         "\"0061i000003XNcDAAW\",\"false\",\"220000.0\",\"2019-02-22T07:03:21.000Z\",\"2018-11-15\",\"12:00:50.000Z\"\n";
-
 
     Schema schema = Schema.recordOf("output",
                                     Schema.Field.of("Id", Schema.of(Schema.Type.STRING)),
@@ -88,12 +87,12 @@ public class SalesforceBulkRecordReaderTest {
 
   @Test
   public void testEmptyResult() throws Exception {
-    String csvString1 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n";
-    String csvString2 = "";
-    String csvString3 =
+    String csvString1 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
       "\"0061i000003XNcBAAW\",\"false\",\"1500.0\",\"2019-02-22T07:03:21.000Z\",\"2019-01-01\",\"12:00:30.000Z\"\n" +
-      "\"0061i000003XNcCAAW\",\"false\",\"112500.0\",\"2019-02-22T07:03:21.000Z\",\"2018-12-20\",\"12:00:40.000Z\"\n" +
-        "\"0061i000003XNcDAAW\",\"false\",\"220000.0\",\"2019-02-22T07:03:21.000Z\",\"2018-11-15\",\"12:00:50.000Z\"\n";
+      "\"0061i000003XNcCAAW\",\"false\",\"112500.0\",\"2019-02-22T07:03:21.000Z\",\"2018-12-20\",\"12:00:40.000Z\"\n";
+      String csvString2 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
+      "\"0061i000003XNcDAAW\",\"false\",\"220000.0\",\"2019-02-22T07:03:21.000Z\",\"2018-11-15\",\"12:00:50.000Z\"\n";
+    String csvString3 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n";
 
 
     Schema schema = Schema.recordOf("output",


### PR DESCRIPTION
The following fixes have been cherrypicked:
1. PLUGIN-711: Close the bulk job when closing record reader.
2. Salesforce source fixes: Only open inputstream when we need to read a query result. Retry when we fail to get batch info.