### PR TITLE
Fix bulk close error "Closing already closed Job not allowed" when pk chunking was enabled

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
@@ -22,7 +22,6 @@ import com.sforce.async.BatchStateEnum;
 import com.sforce.async.BulkConnection;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.salesforce.BulkAPIBatchException;
-import io.cdap.plugin.salesforce.SalesforceBulkUtil;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
@@ -159,13 +158,6 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
       // this also closes the inputStream
       csvParser.close();
       csvParser = null;
-    }
-    if (bulkConnection != null) {
-      try {
-        SalesforceBulkUtil.closeJob(bulkConnection, jobId);
-      } catch (AsyncApiException e) {
-        throw new IOException(e);
-      }
     }
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormat.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormat.java
@@ -15,24 +15,11 @@
  */
 package io.cdap.plugin.salesforce.plugin.source.batch;
 
-import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.sforce.async.AsyncApiException;
-import com.sforce.async.BatchInfo;
-import com.sforce.async.BatchStateEnum;
-import com.sforce.async.BulkConnection;
-import com.sforce.async.JobInfo;
-import com.sforce.async.JobStateEnum;
-import com.sforce.async.OperationEnum;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.plugin.salesforce.BulkAPIBatchException;
 import io.cdap.plugin.salesforce.SObjectDescriptor;
-import io.cdap.plugin.salesforce.SalesforceBulkUtil;
-import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
-import io.cdap.plugin.salesforce.authenticator.Authenticator;
-import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.apache.hadoop.conf.Configuration;
@@ -44,16 +31,11 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Input format class which generates input splits for each given query and initializes appropriate record reader.
@@ -63,34 +45,16 @@ public class SalesforceInputFormat extends InputFormat {
   private static final Logger LOG = LoggerFactory.getLogger(SalesforceInputFormat.class);
 
   private static final Gson GSON = new Gson();
-  private static final Type QUERIES_TYPE = new TypeToken<List<String>>() { }.getType();
   private static final Type SCHEMAS_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+  private static final Type QUERY_SPLITS_TYPE = new TypeToken<List<SalesforceSplit>>() { }.getType();
 
   @Override
   public List<InputSplit> getSplits(JobContext context) {
     Configuration configuration = context.getConfiguration();
-    List<String> queries = GSON.fromJson(configuration.get(SalesforceSourceConstants.CONFIG_QUERIES), QUERIES_TYPE);
-    BulkConnection bulkConnection = getBulkConnection(configuration);
-
-    boolean enablePKChunk = configuration.getBoolean(SalesforceSourceConstants.CONFIG_PK_CHUNK_ENABLE, false);
-    if (enablePKChunk) {
-      String parent = configuration.get(SalesforceSourceConstants.CONFIG_CHUNK_PARENT);
-      int chunkSize = configuration.getInt(SalesforceSourceConstants.CONFIG_CHUNK_SIZE,
-                                           SalesforceSourceConstants.DEFAULT_PK_CHUNK_SIZE);
-
-      List<String> chunkHeaderValues = new ArrayList<>();
-      chunkHeaderValues.add(String.format(SalesforceSourceConstants.HEADER_VALUE_PK_CHUNK, chunkSize));
-      if (!Strings.isNullOrEmpty(parent)) {
-        chunkHeaderValues.add(String.format(SalesforceSourceConstants.HEADER_PK_CHUNK_PARENT, parent));
-      }
-
-      bulkConnection.addHeader(SalesforceSourceConstants.HEADER_ENABLE_PK_CHUNK, String.join(";", chunkHeaderValues));
-    }
-
-    return queries.parallelStream()
-      .map(query -> getQuerySplits(query, bulkConnection, enablePKChunk))
-      .flatMap(Collection::stream)
-      .collect(Collectors.toList());
+    List<SalesforceSplit> querySplits = GSON.fromJson(
+      configuration.get(SalesforceSourceConstants.CONFIG_QUERY_SPLITS), QUERY_SPLITS_TYPE);
+    // this is needed to convert List<SalesforceSplits> to List<InputSplit>
+    return querySplits.parallelStream().collect(Collectors.toList());
   }
 
   @Override
@@ -110,53 +74,6 @@ public class SalesforceInputFormat extends InputFormat {
     return new SalesforceRecordReaderWrapper(sObjectName, sObjectNameField, getDelegateRecordReader(query, schema));
   }
 
-
-
-  private List<SalesforceSplit> getQuerySplits(String query, BulkConnection bulkConnection, boolean enablePKChunk) {
-    return Stream.of(getBatches(query, bulkConnection, enablePKChunk))
-      .map(batch -> new SalesforceSplit(batch.getJobId(), batch.getId(), query))
-      .collect(Collectors.toList());
-  }
-
-  /**
-   * Initializes bulk connection based on given Hadoop configuration.
-   *
-   * @param conf Hadoop configuration
-   * @return bulk connection instance
-   */
-  private BulkConnection getBulkConnection(Configuration conf) {
-    try {
-      AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
-      return new BulkConnection(Authenticator.createConnectorConfig(credentials));
-    } catch (AsyncApiException e) {
-      throw new RuntimeException("There was issue communicating with Salesforce", e);
-    }
-  }
-
-  /**
-   * Based on query length sends query to Salesforce to receive array of batch info. If query is within limit, executes
-   * original query. If not, switches to wide object logic, i.e. generates Id query to retrieve batch info for Ids only
-   * that will be used later to retrieve data using SOAP API.
-   *
-   * @param query SOQL query
-   * @param bulkConnection bulk connection
-   * @param enablePKChunk enable PK Chunking
-   * @return array of batch info
-   */
-  private BatchInfo[] getBatches(String query, BulkConnection bulkConnection, boolean enablePKChunk) {
-    try {
-      if (!SalesforceQueryUtil.isQueryUnderLengthLimit(query)) {
-        LOG.debug("Wide object query detected. Query length '{}'", query.length());
-        query = SalesforceQueryUtil.createSObjectIdQuery(query);
-      }
-      BatchInfo[] batches = runBulkQuery(bulkConnection, query, enablePKChunk);
-      LOG.debug("Number of batches received from Salesforce: '{}'", batches.length);
-      return batches;
-    } catch (AsyncApiException | IOException e) {
-      throw new RuntimeException("There was issue communicating with Salesforce", e);
-    }
-  }
-
   private RecordReader<Schema, Map<String, ?>> getDelegateRecordReader(String query, Schema schema) {
     if (SalesforceQueryParser.isRestrictedQuery(query)) {
       LOG.info("The SOQL query uses an aggregate function call or offset. "
@@ -171,79 +88,4 @@ public class SalesforceInputFormat extends InputFormat {
     return new SalesforceWideRecordReader(schema, query, new SoapRecordToMapTransformer());
   }
 
-  /**
-   * Start batch job of reading a given guery result.
-   *
-   * @param bulkConnection bulk connection instance
-   * @param query a SOQL query
-   * @param enablePKChunk enable PK Chunk
-   * @return an array of batches
-   * @throws AsyncApiException  if there is an issue creating the job
-   * @throws IOException failed to close the query
-   */
-  public BatchInfo[] runBulkQuery(BulkConnection bulkConnection, String query, boolean enablePKChunk)
-    throws AsyncApiException, IOException {
-
-    SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
-    JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.query, null);
-    BatchInfo batchInfo;
-    try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
-      batchInfo = bulkConnection.createBatchFromStream(job, bout);
-    }
-
-    if (enablePKChunk) {
-      return waitForBatchChunks(bulkConnection, job.getId(), batchInfo.getId());
-    }
-    BatchInfo[] batchInfos = bulkConnection.getBatchInfoList(job.getId()).getBatchInfo();
-    LOG.info("Job id {}, status: {}", job.getId(), bulkConnection.getJobStatus(job.getId()).getState());
-    if (batchInfos.length > 0) {
-      LOG.info("Batch size {}, state {}", batchInfos.length, batchInfos[0].getState());
-    }
-    return batchInfos;
-  }
-
-  /** When PK Chunk is enabled, wait for state of initial batch to be NotProcessed, in this case Salesforce API will
-   * decide how many batches will be created
-   * @param bulkConnection bulk connection instance
-   * @param jobId a job id
-   * @param initialBatchId a batch id
-   * @return Array with Batches created by Salesforce API
-   *
-   * @throws AsyncApiException if there is an issue creating the job
-   */
-  private BatchInfo[] waitForBatchChunks(BulkConnection bulkConnection, String jobId, String initialBatchId)
-    throws AsyncApiException {
-    BatchInfo initialBatchInfo = null;
-    for (int i = 0; i < SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES; i++) {
-      //check if the job is aborted
-      if (bulkConnection.getJobStatus(jobId).getState() == JobStateEnum.Aborted) {
-        LOG.info(String.format("Job with Id: '%s' is aborted", jobId));
-        return new BatchInfo[0];
-      }
-      try {
-        initialBatchInfo = bulkConnection.getBatchInfo(jobId, initialBatchId);
-      } catch (AsyncApiException e) {
-        if (i == SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES - 1) {
-          throw e;
-        }
-        LOG.warn("Failed to get info for batch {}. Will retry after some time.", initialBatchId, e);
-        continue;
-      }
-
-      if (initialBatchInfo.getState() == BatchStateEnum.NotProcessed) {
-        BatchInfo[] result = bulkConnection.getBatchInfoList(jobId).getBatchInfo();
-        return Arrays.stream(result).filter(batchInfo -> batchInfo.getState() != BatchStateEnum.NotProcessed)
-          .toArray(BatchInfo[]::new);
-      } else if (initialBatchInfo.getState() == BatchStateEnum.Failed) {
-        throw new BulkAPIBatchException("Batch failed", initialBatchInfo);
-      } else {
-        try {
-          Thread.sleep(SalesforceSourceConstants.GET_BATCH_RESULTS_SLEEP_MS);
-        } catch (InterruptedException e) {
-          throw new RuntimeException("Job is aborted", e);
-        }
-      }
-    }
-    throw new BulkAPIBatchException("Timeout waiting for batch results", initialBatchInfo);
-  }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
@@ -38,13 +38,12 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
   private final Map<String, String> conf;
 
   public SalesforceInputFormatProvider(SalesforceBaseSourceConfig config,
-                                       List<String> queries,
                                        Map<String, String> schemas,
+                                       List<SalesforceSplit> querySplits,
                                        @Nullable String sObjectNameField) {
     ImmutableMap.Builder<String, String> configBuilder = new ImmutableMap.Builder<String, String>()
-      .put(SalesforceSourceConstants.CONFIG_QUERIES, GSON.toJson(queries))
       .put(SalesforceSourceConstants.CONFIG_SCHEMAS, GSON.toJson(schemas));
-
+    configBuilder.put(SalesforceSourceConstants.CONFIG_QUERY_SPLITS, GSON.toJson(querySplits));
     OAuthInfo oAuthInfo = config.getOAuthInfo();
     if (oAuthInfo != null) {
       configBuilder
@@ -62,15 +61,6 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
     if (sObjectNameField != null) {
       configBuilder.put(SalesforceSourceConstants.CONFIG_SOBJECT_NAME_FIELD, sObjectNameField);
     }
-
-    if (config instanceof SalesforceSourceConfig) {
-      SalesforceSourceConfig sourceConfig = (SalesforceSourceConfig) config;
-      configBuilder
-        .put(SalesforceSourceConstants.CONFIG_PK_CHUNK_ENABLE, String.valueOf(sourceConfig.getEnablePKChunk()))
-        .put(SalesforceSourceConstants.CONFIG_CHUNK_SIZE, String.valueOf(sourceConfig.getChunkSize()))
-        .put(SalesforceSourceConstants.CONFIG_CHUNK_PARENT, sourceConfig.getParent());
-    }
-
     this.conf = configBuilder.build();
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -40,12 +40,9 @@ public class SalesforceSourceConstants {
   public static final String PROPERTY_BLACK_LIST = "blackList";
   public static final String PROPERTY_SOBJECT_NAME_FIELD = "sObjectNameField";
 
-  public static final String CONFIG_QUERIES = "mapred.salesforce.input.queries";
   public static final String CONFIG_SCHEMAS = "mapred.salesforce.input.schemas";
+  public static final String CONFIG_QUERY_SPLITS = "mapred.salesforce.input.query.splits";
 
-  public static final String CONFIG_PK_CHUNK_ENABLE = "mapred.salesforce.input.pk.chunk";
-  public static final String CONFIG_CHUNK_SIZE = "mapred.salesforce.input.schemas.chunk.size";
-  public static final String CONFIG_CHUNK_PARENT = "mapred.salesforce.input.schemas.chunk.parent";
   public static final String HEADER_ENABLE_PK_CHUNK = "Sforce-Enable-PKChunking";
   public static final String HEADER_VALUE_PK_CHUNK = "chunkSize=%d";
   public static final String HEADER_PK_CHUNK_PARENT = "parent=%s";

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce.plugin.source.batch.util;
+
+import com.sforce.async.AsyncApiException;
+import com.sforce.async.BatchInfo;
+import com.sforce.async.BatchStateEnum;
+import com.sforce.async.BulkConnection;
+import com.sforce.async.JobInfo;
+import com.sforce.async.JobStateEnum;
+import com.sforce.async.OperationEnum;
+import io.cdap.plugin.salesforce.BulkAPIBatchException;
+import io.cdap.plugin.salesforce.SObjectDescriptor;
+import io.cdap.plugin.salesforce.SalesforceBulkUtil;
+import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
+import io.cdap.plugin.salesforce.SalesforceQueryUtil;
+import io.cdap.plugin.salesforce.authenticator.Authenticator;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utility class which provides methods to generate Salesforce splits for a query.
+ */
+public final class SalesforceSplitUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SalesforceSplitUtil.class);
+
+  /**
+   * Generates and returns Salesforce splits for a query
+   * @param query the query for the sobject
+   * @param bulkConnection used to create salesforce jobs
+   * @param enablePKChunk indicates if pk chunking is enabled
+   * @return list of salesforce splits
+   */
+  public static List<SalesforceSplit> getQuerySplits(String query, BulkConnection bulkConnection,
+                                                     boolean enablePKChunk) {
+    return Stream.of(getBatches(query, bulkConnection, enablePKChunk))
+      .map(batch -> new SalesforceSplit(batch.getJobId(), batch.getId(), query))
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * Based on query length sends query to Salesforce to receive array of batch info. If query is within limit, executes
+   * original query. If not, switches to wide object logic, i.e. generates Id query to retrieve batch info for Ids only
+   * that will be used later to retrieve data using SOAP API.
+   *
+   * @param query SOQL query
+   * @param bulkConnection bulk connection
+   * @param enablePKChunk enable PK Chunking
+   * @return array of batch info
+   */
+  private static BatchInfo[] getBatches(String query, BulkConnection bulkConnection, boolean enablePKChunk) {
+    try {
+      if (!SalesforceQueryUtil.isQueryUnderLengthLimit(query)) {
+        LOG.debug("Wide object query detected. Query length '{}'", query.length());
+        query = SalesforceQueryUtil.createSObjectIdQuery(query);
+      }
+      BatchInfo[] batches = runBulkQuery(bulkConnection, query, enablePKChunk);
+      LOG.debug("Number of batches received from Salesforce: '{}'", batches.length);
+      return batches;
+    } catch (AsyncApiException | IOException e) {
+      throw new RuntimeException("There was issue communicating with Salesforce", e);
+    }
+  }
+
+  /**
+   * Start batch job of reading a given guery result.
+   *
+   * @param bulkConnection bulk connection instance
+   * @param query a SOQL query
+   * @param enablePKChunk enable PK Chunk
+   * @return an array of batches
+   * @throws AsyncApiException  if there is an issue creating the job
+   * @throws IOException failed to close the query
+   */
+  private static BatchInfo[] runBulkQuery(BulkConnection bulkConnection, String query, boolean enablePKChunk)
+    throws AsyncApiException, IOException {
+
+    SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
+    JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.query, null);
+    BatchInfo batchInfo;
+    try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
+      batchInfo = bulkConnection.createBatchFromStream(job, bout);
+    }
+
+    if (enablePKChunk) {
+      LOG.debug("PKChunking is enabled");
+      return waitForBatchChunks(bulkConnection, job.getId(), batchInfo.getId());
+    }
+    LOG.debug("PKChunking is not enabled");
+    BatchInfo[] batchInfos = bulkConnection.getBatchInfoList(job.getId()).getBatchInfo();
+    LOG.info("Job id {}, status: {}", job.getId(), bulkConnection.getJobStatus(job.getId()).getState());
+    if (batchInfos.length > 0) {
+      LOG.info("Batch size {}, state {}", batchInfos.length, batchInfos[0].getState());
+    }
+    return batchInfos;
+  }
+
+
+  /**
+   * Initializes bulk connection based on given Hadoop credentials configuration.
+   *
+   * @return bulk connection instance
+   */
+  public static BulkConnection getBulkConnection(String username, String password,
+                                                 String consumerKey, String consumerSecret, String loginUrl) {
+    AuthenticatorCredentials authenticatorCredentials = SalesforceConnectionUtil
+      .getAuthenticatorCredentials(username, password, consumerKey, consumerSecret, loginUrl);
+    try {
+      return new BulkConnection(Authenticator.createConnectorConfig(authenticatorCredentials));
+    } catch (AsyncApiException e) {
+      throw new RuntimeException("There was issue communicating with Salesforce", e);
+    }
+  }
+
+  /**
+   * Initializes bulk connection based on given Hadoop credentials configuration.
+   *
+   * @return bulk connection instance
+   */
+  public static BulkConnection getBulkConnection(AuthenticatorCredentials authenticatorCredentials) {
+    try {
+      return new BulkConnection(Authenticator.createConnectorConfig(authenticatorCredentials));
+    } catch (AsyncApiException e) {
+      throw new RuntimeException("There was issue communicating with Salesforce", e);
+    }
+  }
+
+  /** When PK Chunk is enabled, wait for state of initial batch to be NotProcessed, in this case Salesforce API will
+   * decide how many batches will be created
+   * @param bulkConnection bulk connection instance
+   * @param jobId a job id
+   * @param initialBatchId a batch id
+   * @return Array with Batches created by Salesforce API
+   *
+   * @throws AsyncApiException if there is an issue creating the job
+   */
+  private static BatchInfo[] waitForBatchChunks(BulkConnection bulkConnection, String jobId, String initialBatchId)
+    throws AsyncApiException {
+    BatchInfo initialBatchInfo = null;
+    for (int i = 0; i < SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES; i++) {
+      //check if the job is aborted
+      if (bulkConnection.getJobStatus(jobId).getState() == JobStateEnum.Aborted) {
+        LOG.info(String.format("Job with Id: '%s' is aborted", jobId));
+        return new BatchInfo[0];
+      }
+      try {
+        initialBatchInfo = bulkConnection.getBatchInfo(jobId, initialBatchId);
+      } catch (AsyncApiException e) {
+        if (i == SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES - 1) {
+          throw e;
+        }
+        LOG.warn("Failed to get info for batch {}. Will retry after some time.", initialBatchId, e);
+        continue;
+      }
+
+      if (initialBatchInfo.getState() == BatchStateEnum.NotProcessed) {
+        BatchInfo[] result = bulkConnection.getBatchInfoList(jobId).getBatchInfo();
+        return Arrays.stream(result).filter(batchInfo -> batchInfo.getState() != BatchStateEnum.NotProcessed)
+          .toArray(BatchInfo[]::new);
+      } else if (initialBatchInfo.getState() == BatchStateEnum.Failed) {
+        throw new BulkAPIBatchException("Batch failed", initialBatchInfo);
+      } else {
+        try {
+          Thread.sleep(SalesforceSourceConstants.GET_BATCH_RESULTS_SLEEP_MS);
+        } catch (InterruptedException e) {
+          throw new RuntimeException("Job is aborted", e);
+        }
+      }
+    }
+    throw new BulkAPIBatchException("Timeout waiting for batch results", initialBatchInfo);
+  }
+
+  public static void closeJobs(List<String> jobIds, AuthenticatorCredentials authenticatorCredentials) {
+    BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
+    RuntimeException runtimeException = null;
+    for (String jobId : jobIds) {
+      try {
+        SalesforceBulkUtil.closeJob(bulkConnection, jobId);
+      } catch (AsyncApiException e) {
+        if (runtimeException == null) {
+          runtimeException = new RuntimeException(e);
+        } else {
+          runtimeException.addSuppressed(e);
+        }
+      }
+    }
+    if (runtimeException != null) {
+      throw runtimeException;
+    }
+  }
+}


### PR DESCRIPTION
Resolve jira - https://cdap.atlassian.net/browse/PLUGIN-777 which would cause the Salesforce plugin to fail with "Closing already closed Job not allowed" error

The fix was to create and close the bulk connection only once by moving it out from InputFormatProvider class to prepareRun() and onRunFinish() methods of the SalesforceBatchSource class. This also means we now generate the splits in prepareRun() and send the serialized splits to InputFormat.

Testing:
SalesforceBatchSource, SalesforceBatchMultiSource and SalesforceMultiObjectSource plugins were tested with an sObject table with ~4M records.
In all the three testing cases, the pipeline succeeded and the logs did not show any errors.