### PR TITLE
PLUGIN-952: Salesforce Streaming Source plugin does not read from topic created by CDF

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforcePushTopicListener.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforcePushTopicListener.java
@@ -51,7 +51,7 @@ public class SalesforcePushTopicListener {
    * Timeout of 110 seconds is enforced by Salesforce Streaming API and is not configurable.
    * So we enforce the same on client.
    */
-  private static final int CONNECTION_TIMEOUT_SECONDS = 110;
+  private static final long CONNECTION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(110);
   private static final long HANDSHAKE_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(110);
 
   private static final int HANDSHAKE_CHECK_INTERVAL_MS = 1000;
@@ -108,7 +108,7 @@ public class SalesforcePushTopicListener {
 
     // Set up a Jetty HTTP client to use with CometD
     HttpClient httpClient = new HttpClient(sslContextFactory);
-    httpClient.setConnectTimeout(CONNECTION_TIMEOUT_SECONDS);
+    httpClient.setConnectTimeout(CONNECTION_TIMEOUT_MS);
     httpClient.start();
 
     // Use the Jackson implementation


### PR DESCRIPTION
[PLUGIN-952](https://cdap.atlassian.net/browse/PLUGIN-952)

Earlier HTTP Client was setting connection timeout in seconds. It has now been been converted into milliseconds.
