### PR TITLE
'Parent-to-child' type Relationship SOQL queries are failing 

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SObjectsDescribeResult.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SObjectsDescribeResult.java
@@ -103,7 +103,7 @@ public class SObjectsDescribeResult {
             String.format("Relationship field name '%s' is absent in SObject '%s' describe result",
               featuredSObjects.getRelationship(), lastDescribe.getName()));
         }
-        lastDescribe = describe(connection, name, cache);
+        lastDescribe = describe(connection, relationshipName, cache);
       }
 
         /*


### PR DESCRIPTION
'Parent-to-child' type Relationship SOQL queries are failing. because while creating the object of SObjectsDescribeResult, if  SObjects having a child relationship we were setting parent object name instead of relationship object name of the object.