### PR TITLE
add queryall operation to batch source and multiobject batch source

### DIFF
--- a/docs/Salesforce-batchsource.md
+++ b/docs/Salesforce-batchsource.md
@@ -257,3 +257,7 @@ PK chunking only works with the following objects:
 Support also includes custom objects, and any Sharing and History tables that support standard objects.
 
 **Chunk Size:** Specify size of chunk. Maximum Size is 250,000. Default Size is 100,000. 
+
+**Query Operation:**
+Specify the query operation to run on the table. If query is selected, only current records will be returned.
+If queryAll is selected, all current and deleted records will be returned. Default operation is query.

--- a/docs/SalesforceMultiObjects-batchsource.md
+++ b/docs/SalesforceMultiObjects-batchsource.md
@@ -198,3 +198,6 @@ Below is a non-comprehensive list of **sObjects** that are not currently availab
 - UserRecordAccess
 - WorkOrderLineItemStatus
 - WorkOrderStatus
+
+**Query Operation:** 
+Specify the query operation to run on the table. If query is selected, only current records will be returned. If queryAll is selected, all current and deleted records will be returned. Default operation is query.

--- a/src/main/java/io/cdap/plugin/salesforce/parser/SalesforceQueryParser.java
+++ b/src/main/java/io/cdap/plugin/salesforce/parser/SalesforceQueryParser.java
@@ -16,11 +16,7 @@
 package io.cdap.plugin.salesforce.parser;
 
 import io.cdap.plugin.salesforce.SObjectDescriptor;
-import org.antlr.v4.runtime.BaseErrorListener;
-import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.CommonTokenStream;
-import org.antlr.v4.runtime.RecognitionException;
-import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.*;
 import soql.SOQLLexer;
 import soql.SOQLParser;
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
@@ -110,8 +110,10 @@ public class SalesforceSinkConfig extends BaseSalesforceConfig {
                               @Nullable String password,
                               @Nullable String loginUrl,
                               String sObject,
-                              String operation, String externalIdField,
-                              String maxBytesPerBatch, String maxRecordsPerBatch,
+                              String operation,
+                              String externalIdField,
+                              String maxBytesPerBatch,
+                              String maxRecordsPerBatch,
                               String errorHandling,
                               @Nullable String securityToken,
                               @Nullable OAuthInfo oAuthInfo) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.salesforce.plugin.source.batch;
 
+import com.sforce.async.OperationEnum;
 import com.sforce.ws.ConnectionException;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -76,6 +77,11 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
   @Macro
   private String offset;
 
+  @Name(SalesforceSourceConstants.PROPERTY_OPERATION)
+  @Description("If set to query, the query result will only return current rows. If set to queryAll, all records, includ" +
+          "ing deletes will be sourced")
+  private String operation;
+
   protected SalesforceBaseSourceConfig(String referenceName,
                                        @Nullable String consumerKey,
                                        @Nullable String consumerSecret,
@@ -86,6 +92,7 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
                                        @Nullable String datetimeBefore,
                                        @Nullable String duration,
                                        @Nullable String offset,
+                                       @Nullable String operation,
                                        @Nullable String securityToken,
                                        @Nullable OAuthInfo oAuthInfo) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, securityToken, oAuthInfo);
@@ -93,6 +100,7 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
     this.datetimeBefore = datetimeBefore;
     this.duration = duration;
     this.offset = offset;
+    this.operation = operation;
   }
 
   public Map<ChronoUnit, Integer> getDuration() {
@@ -270,4 +278,17 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
   private ZonedDateTime parseDatetime(String datetime) throws DateTimeParseException {
     return StringUtils.isBlank(datetime) ? null : ZonedDateTime.parse(datetime, DateTimeFormatter.ISO_DATE_TIME);
   }
+  public String getOperation() {
+    return operation;
+  }
+
+  public OperationEnum getOperationEnum() {
+    try {
+      return OperationEnum.valueOf(operation);
+    } catch (IllegalArgumentException ex) {
+      throw new InvalidConfigException("Unsupported value for operation: " + operation,
+              SalesforceSourceConstants.PROPERTY_OPERATION);
+    }
+  }
+
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -150,8 +150,7 @@ public abstract class SalesforceBaseSourceConfig extends BaseSalesforceConfig {
    */
   protected String getSObjectQuery(String sObjectName, Schema schema, long logicalStartTime) {
     try {
-      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName, getAuthenticatorCredentials(),
-                                                                       SalesforceSchemaUtil.COMPOUND_FIELDS);
+      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName, getAuthenticatorCredentials(), SalesforceSchemaUtil.COMPOUND_FIELDS);
 
       List<String> sObjectFields = sObjectDescriptor.getFieldsNames();
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
@@ -98,9 +98,10 @@ public class SalesforceBatchMultiSource extends BatchSource<Schema, Map<String, 
 
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
 
+    Enum operation = config.getOperationEnum();
 
     List<SalesforceSplit> querySplits = queries.parallelStream()
-      .map(query -> SalesforceSplitUtil.getQuerySplits(query, bulkConnection, false, OperationEnum.queryAll))
+      .map(query -> SalesforceSplitUtil.getQuerySplits(query, bulkConnection, false, operation))
       .flatMap(Collection::stream).collect(Collectors.toList());
     // store the jobIds so be used in onRunFinish() to close the connections
     querySplits.parallelStream().forEach(salesforceSplit -> jobIds.add(salesforceSplit.getJobId()));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
@@ -98,10 +98,9 @@ public class SalesforceBatchMultiSource extends BatchSource<Schema, Map<String, 
 
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
 
-    Enum operation = config.getOperationEnum();
 
     List<SalesforceSplit> querySplits = queries.parallelStream()
-      .map(query -> SalesforceSplitUtil.getQuerySplits(query, bulkConnection, false, operation))
+      .map(query -> SalesforceSplitUtil.getQuerySplits(query, bulkConnection, false, config.getOperation()))
       .flatMap(Collection::stream).collect(Collectors.toList());
     // store the jobIds so be used in onRunFinish() to close the connections
     querySplits.parallelStream().forEach(salesforceSplit -> jobIds.add(salesforceSplit.getJobId()));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -117,6 +117,8 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
                                                                                     config.getLoginUrl());
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
     boolean enablePKChunk = config.getEnablePKChunk();
+    Enum operation = config.getOperationEnum();
+
     if (enablePKChunk) {
       String parent = config.getParent();
       int chunkSize = config.getChunkSize();
@@ -127,7 +129,7 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
       }
       bulkConnection.addHeader(SalesforceSourceConstants.HEADER_ENABLE_PK_CHUNK, String.join(";", chunkHeaderValues));
     }
-    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnection, enablePKChunk);
+    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnection, enablePKChunk, operation);
     querySplits.parallelStream().forEach(salesforceSplit -> jobIds.add(salesforceSplit.getJobId()));
     context.setInput(Input.of(config.referenceName, new SalesforceInputFormatProvider(
     config, ImmutableMap.of(sObjectName, schema.toString()), querySplits, null)));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -117,7 +117,6 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
                                                                                     config.getLoginUrl());
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
     boolean enablePKChunk = config.getEnablePKChunk();
-    Enum operation = config.getOperationEnum();
 
     if (enablePKChunk) {
       String parent = config.getParent();
@@ -129,7 +128,7 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
       }
       bulkConnection.addHeader(SalesforceSourceConstants.HEADER_ENABLE_PK_CHUNK, String.join(";", chunkHeaderValues));
     }
-    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnection, enablePKChunk, operation);
+    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnection, enablePKChunk,  config.getOperation());
     querySplits.parallelStream().forEach(salesforceSplit -> jobIds.add(salesforceSplit.getJobId()));
     context.setInput(Input.of(config.referenceName, new SalesforceInputFormatProvider(
     config, ImmutableMap.of(sObjectName, schema.toString()), querySplits, null)));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
@@ -83,9 +83,10 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
                                      @Nullable String blackList,
                                      @Nullable String sObjectNameField,
                                      @Nullable String securityToken,
-                                     @Nullable OAuthInfo oAuthInfo) {
+                                     @Nullable OAuthInfo oAuthInfo,
+                                     @Nullable String operation)  {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
-          datetimeAfter, datetimeBefore, duration, offset, securityToken, oAuthInfo);
+          datetimeAfter, datetimeBefore, duration, offset, operation, securityToken, oAuthInfo);
     this.whiteList = whiteList;
     this.blackList = blackList;
     this.sObjectNameField = sObjectNameField;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -17,7 +17,6 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.sforce.async.OperationEnum;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.ws.ConnectionException;
 import io.cdap.cdap.api.annotation.Description;
@@ -89,11 +88,6 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   @Description("Parent of the Salesforce Object. This is used to enable chunking for history tables or shared objects.")
   private String parent;
 
-  @Name(SalesforceSourceConstants.PROPERTY_OPERATION)
-  @Description("If set to query, the query result will only return current rows. If set to queryAll, all records, includ" +
-          "ing deletes will be sourced")
-  private String operation;
-
   @VisibleForTesting
   SalesforceSourceConfig(String referenceName,
                          @Nullable String consumerKey,
@@ -110,19 +104,18 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
                          @Nullable String schema,
                          @Nullable String securityToken,
                          @Nullable OAuthInfo oAuthInfo,
+                         @Nullable String operation,
                          @Nullable Boolean enablePKChunk,
                          @Nullable Integer chunkSize,
-                         @Nullable String parent,
-                         String operation) {
+                         @Nullable String parent) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
-          datetimeAfter, datetimeBefore, duration, offset, securityToken, oAuthInfo);
+          datetimeAfter, datetimeBefore, duration, offset, operation, securityToken, oAuthInfo);
     this.query = query;
     this.sObjectName = sObjectName;
     this.schema = schema;
     this.enablePKChunk = enablePKChunk;
     this.chunkSize = chunkSize;
     this.parent = parent;
-    this.operation = operation;
   }
 
   /**
@@ -319,20 +312,6 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   public boolean getEnablePKChunk() {
     return enablePKChunk == null ? false : enablePKChunk;
   }
-
-  public String getOperation() {
-    return operation;
-  }
-
-  public OperationEnum getOperationEnum() {
-    try {
-      return OperationEnum.valueOf(operation.toLowerCase());
-    } catch (IllegalArgumentException ex) {
-      throw new InvalidConfigException("Unsupported value for operation: " + operation,
-              SalesforceSourceConstants.PROPERTY_OPERATION);
-    }
-  }
-
 
   public int getChunkSize() {
     return chunkSize == null ? SalesforceSourceConstants.DEFAULT_PK_CHUNK_SIZE : chunkSize;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -17,6 +17,7 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.sforce.async.OperationEnum;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.ws.ConnectionException;
 import io.cdap.cdap.api.annotation.Description;
@@ -88,6 +89,11 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   @Description("Parent of the Salesforce Object. This is used to enable chunking for history tables or shared objects.")
   private String parent;
 
+  @Name(SalesforceSourceConstants.PROPERTY_OPERATION)
+  @Description("If set to query, the query result will only return current rows. If set to queryAll, all records, includ" +
+          "ing deletes will be sourced")
+  private String operation;
+
   @VisibleForTesting
   SalesforceSourceConfig(String referenceName,
                          @Nullable String consumerKey,
@@ -106,7 +112,8 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
                          @Nullable OAuthInfo oAuthInfo,
                          @Nullable Boolean enablePKChunk,
                          @Nullable Integer chunkSize,
-                         @Nullable String parent) {
+                         @Nullable String parent,
+                         String operation) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
           datetimeAfter, datetimeBefore, duration, offset, securityToken, oAuthInfo);
     this.query = query;
@@ -115,6 +122,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
     this.enablePKChunk = enablePKChunk;
     this.chunkSize = chunkSize;
     this.parent = parent;
+    this.operation = operation;
   }
 
   /**
@@ -311,6 +319,20 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   public boolean getEnablePKChunk() {
     return enablePKChunk == null ? false : enablePKChunk;
   }
+
+  public String getOperation() {
+    return operation;
+  }
+
+  public OperationEnum getOperationEnum() {
+    try {
+      return OperationEnum.valueOf(operation.toLowerCase());
+    } catch (IllegalArgumentException ex) {
+      throw new InvalidConfigException("Unsupported value for operation: " + operation,
+              SalesforceSourceConstants.PROPERTY_OPERATION);
+    }
+  }
+
 
   public int getChunkSize() {
     return chunkSize == null ? SalesforceSourceConstants.DEFAULT_PK_CHUNK_SIZE : chunkSize;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -47,6 +47,8 @@ public class SalesforceSourceConstants {
   public static final String HEADER_VALUE_PK_CHUNK = "chunkSize=%d";
   public static final String HEADER_PK_CHUNK_PARENT = "parent=%s";
 
+  public static final String PROPERTY_OPERATION = "operation";
+
   public static final String CONFIG_SOBJECT_NAME_FIELD = "mapred.salesforce.input.sObjectNameField";
 
   public static final int WIDE_QUERY_MAX_BATCH_COUNT = 2000;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
@@ -55,7 +55,7 @@ public final class SalesforceSplitUtil {
    * @param operation indicates they query type
    * @return list of salesforce splits
    */
-  public static List<SalesforceSplit> getQuerySplits(String query, BulkConnection bulkConnection, boolean enablePKChunk, Enum operation) {
+  public static List<SalesforceSplit> getQuerySplits(String query, BulkConnection bulkConnection, boolean enablePKChunk, String operation) {
     return Stream.of(getBatches(query, bulkConnection, enablePKChunk, operation))
       .map(batch -> new SalesforceSplit(batch.getJobId(), batch.getId(), query))
       .collect(Collectors.toList());
@@ -73,7 +73,7 @@ public final class SalesforceSplitUtil {
    * @return array of batch info
    */
   private static BatchInfo[] getBatches(
-          String query, BulkConnection bulkConnection, boolean enablePKChunk, Enum operation) {
+          String query, BulkConnection bulkConnection, boolean enablePKChunk, String operation) {
     try {
       if (!SalesforceQueryUtil.isQueryUnderLengthLimit(query)) {
         LOG.debug("Wide object query detected. Query length '{}'", query.length());
@@ -98,11 +98,11 @@ public final class SalesforceSplitUtil {
    * @throws AsyncApiException  if there is an issue creating the job
    * @throws IOException failed to close the query
    */
-  private static BatchInfo[] runBulkQuery(BulkConnection bulkConnection, String query, boolean enablePKChunk, Enum operation)
+  private static BatchInfo[] runBulkQuery(BulkConnection bulkConnection, String query, boolean enablePKChunk, String operation)
     throws AsyncApiException, IOException {
 
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
-    JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.query, null);
+    JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectDescriptor.getName(), OperationEnum.valueOf(operation), null);
     BatchInfo batchInfo;
     try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
       batchInfo = bulkConnection.createBatchFromStream(job, bout);

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -37,6 +37,7 @@ public class SalesforceSourceConfigBuilder {
   private Boolean enablePKChunk;
   private Integer chunkSize;
   private String parent;
+  private String queryType;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -123,9 +124,15 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
+  public SalesforceSourceConfigBuilder setQueryType(String queryType) {
+    this.queryType = queryType;
+    return this;
+  }
+
+
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                       query, sObjectName, datetimeAfter, datetimeBefore, duration, offset, schema,
-                                      securityToken, null, enablePKChunk, chunkSize, parent);
+                                      securityToken, null, enablePKChunk, chunkSize, parent, queryType);
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -37,7 +37,7 @@ public class SalesforceSourceConfigBuilder {
   private Boolean enablePKChunk;
   private Integer chunkSize;
   private String parent;
-  private String queryType;
+  private String operation;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -124,15 +124,14 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
-  public SalesforceSourceConfigBuilder setQueryType(String queryType) {
-    this.queryType = queryType;
+  public SalesforceSourceConfigBuilder setOperation(String operation) {
+    this.operation = operation;
     return this;
   }
-
 
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                       query, sObjectName, datetimeAfter, datetimeBefore, duration, offset, schema,
-                                      securityToken, null, enablePKChunk, chunkSize, parent, queryType);
+                                      securityToken, null, operation, enablePKChunk, chunkSize, parent);
   }
 }

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -147,8 +147,8 @@
       "properties": [
         {
           "widget-type": "radio-group",
-          "label": "SOQL Query Operation",
-          "name": "SOQL Query Operation",
+          "label": "operation",
+          "name": "operation",
           "widget-attributes": {
             "layout": "inline",
             "default": "query",

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -176,6 +176,25 @@
           "widget-attributes" : {
             "placeholder": "Salesforce object parent name"
           }
+        },
+        {
+          "widget-type": "radio-group",
+          "label": "operation",
+          "name": "operation",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "query",
+            "options": [
+              {
+                "id": "query",
+                "label": "Query"
+              },
+              {
+                "id": "queryAll",
+                "label": "QueryAll"
+              }
+            ]
+          }
         }
       ]
     }

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -146,6 +146,25 @@
       "label": "Advanced",
       "properties": [
         {
+          "widget-type": "radio-group",
+          "label": "SOQL Query Operation",
+          "name": "SOQL Query Operation",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "query",
+            "options": [
+              {
+                "id": "query",
+                "label": "query"
+              },
+              {
+                "id": "queryAll",
+                "label": "queryAll"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "toggle",
           "name": "enablePKChunk",
           "label": "Enable PK Chunking",
@@ -175,25 +194,6 @@
           "widget-type": "textbox",
           "widget-attributes" : {
             "placeholder": "Salesforce object parent name"
-          }
-        },
-        {
-          "widget-type": "radio-group",
-          "label": "operation",
-          "name": "operation",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "query",
-            "options": [
-              {
-                "id": "query",
-                "label": "Query"
-              },
-              {
-                "id": "queryAll",
-                "label": "QueryAll"
-              }
-            ]
           }
         }
       ]

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -147,7 +147,7 @@
       "properties": [
         {
           "widget-type": "radio-group",
-          "label": "operation",
+          "label": "SOQL Operation Type",
           "name": "operation",
           "widget-attributes": {
             "layout": "inline",

--- a/widgets/SalesforceMultiObjects-batchsource.json
+++ b/widgets/SalesforceMultiObjects-batchsource.json
@@ -142,6 +142,25 @@
       "label": "Advanced",
       "properties": [
         {
+          "widget-type": "radio-group",
+          "label": "SOQL Query Operation",
+          "name": "SOQL Query Operation",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "query",
+            "options": [
+              {
+                "id": "query",
+                "label": "query"
+              },
+              {
+                "id": "queryAll",
+                "label": "queryAll"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "SObject Name Field",
           "name": "sObjectNameField",

--- a/widgets/SalesforceMultiObjects-batchsource.json
+++ b/widgets/SalesforceMultiObjects-batchsource.json
@@ -143,7 +143,7 @@
       "properties": [
         {
           "widget-type": "radio-group",
-          "label": "operation",
+          "label": "SOQL Operation Type",
           "name": "operation",
           "widget-attributes": {
             "layout": "inline",

--- a/widgets/SalesforceMultiObjects-batchsource.json
+++ b/widgets/SalesforceMultiObjects-batchsource.json
@@ -143,8 +143,8 @@
       "properties": [
         {
           "widget-type": "radio-group",
-          "label": "SOQL Query Operation",
-          "name": "SOQL Query Operation",
+          "label": "operation",
+          "name": "operation",
           "widget-attributes": {
             "layout": "inline",
             "default": "query",


### PR DESCRIPTION
made changes to incorporate query and queryAll selection option for SQL queries. If user selects query then only the current records are sourced. If the user select queryAll, the query includes any deletes that have occurred
 