### PR TITLE
Fix onRunFinish warning when pkChunking is enabled

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
@@ -38,9 +38,11 @@ import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -59,7 +61,7 @@ public class SalesforceBatchMultiSource extends BatchSource<Schema, Map<String, 
 
   private final SalesforceMultiSourceConfig config;
   private MapToRecordTransformer transformer;
-  private List<String> jobIds = new ArrayList<>();
+  private Set<String> jobIds = new HashSet<>();
   private AuthenticatorCredentials authenticatorCredentials;
 
   public SalesforceBatchMultiSource(SalesforceMultiSourceConfig config) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -42,8 +42,10 @@ import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConsta
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -60,7 +62,7 @@ public class SalesforceBatchSource extends BatchSource<Schema, Map<String, Strin
   private final SalesforceSourceConfig config;
   private Schema schema;
   private MapToRecordTransformer transformer;
-  private List<String> jobIds = new ArrayList<>();
+  private Set<String> jobIds = new HashSet<>();
   private AuthenticatorCredentials authenticatorCredentials;
 
   public SalesforceBatchSource(SalesforceSourceConfig config) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -193,7 +194,7 @@ public final class SalesforceSplitUtil {
     throw new BulkAPIBatchException("Timeout waiting for batch results", initialBatchInfo);
   }
 
-  public static void closeJobs(List<String> jobIds, AuthenticatorCredentials authenticatorCredentials) {
+  public static void closeJobs(Set<String> jobIds, AuthenticatorCredentials authenticatorCredentials) {
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
     RuntimeException runtimeException = null;
     for (String jobId : jobIds) {


### PR DESCRIPTION
Tested the below scenarios
1. SFBatchSource without pk chunking
2. SFBatchSource with pk chunking
3. SFMultiSource
No warning/exceptions were observed in the pipeline logs