### PR TITLE
 [PLUGIN-1545] changes for validateschema and duplicate records - develop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -783,7 +783,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.1.0-SNAPSHOT</version>
+          <version>0.3.0-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -126,23 +126,27 @@ public class SalesforceSourceConstants {
                                                                                    "WorkOrderLineItem");
 
   /**
-   * Salesforce Bulk API has a limitation, which is 10 minutes per processing of a batch
+   * Salesforce Bulk API has a limitation, which is 5 minutes per processing of a batch, after that it will
+   * retry 20 times before failing the batch. Refer below link.
+   * https://developer.salesforce.com/docs/atlas.en-us.242.0.salesforce_app_limits_cheatsheet.meta/
+   * salesforce_app_limits_cheatsheet/salesforce_app_limits_platform_bulkapi.htm
    */
-  public static final long GET_BATCH_WAIT_TIME_SECONDS = 600;
+  public static final long GET_BATCH_WAIT_TIME_SECONDS = 6000;
   /**
    * Sleep time between polling the batch status
    */
-  public static final long GET_BATCH_RESULTS_SLEEP_MS = 500;
+  public static final long GET_BATCH_RESULTS_SLEEP_MS = 5000;
 
   /**
    * Sleep time between polling the batch status for Salesforce Sink
    */
   public static final long GET_SINK_BATCH_RESULTS_SLEEP_MS = 5000;
-  
+
   /**
    * Number of tries while polling the batch status
    */
-  public static final long GET_BATCH_RESULTS_TRIES = GET_BATCH_WAIT_TIME_SECONDS * (1000 / GET_BATCH_RESULTS_SLEEP_MS);
+  public static final long GET_BATCH_RESULTS_TRIES = (long) (GET_BATCH_WAIT_TIME_SECONDS *
+    (1000 * 1.0 / GET_BATCH_RESULTS_SLEEP_MS));
 
   /**
    * Salesforce Bulk API has a limitation, which is 10 minutes per processing of a batch. But for serial mode,
@@ -150,4 +154,6 @@ public class SalesforceSourceConstants {
    * So, setting this to a large value to avoid timeout issues.
    */
   public static final long GET_BATCH_WAIT_TIME_SECONDS_SERIAL_MODE = 600000;
+
+  public static final long MAX_RETRIES_ON_API_FAILURE = 10;
 }

--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceBulkUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceBulkUtilTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce;
+
+import com.sforce.async.AsyncApiException;
+import com.sforce.async.AsyncExceptionCode;
+import com.sforce.async.BatchInfo;
+import com.sforce.async.BatchInfoList;
+import com.sforce.async.BatchStateEnum;
+import com.sforce.async.BulkConnection;
+import com.sforce.async.ConcurrencyMode;
+import com.sforce.async.JobInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link SalesforceBulkUtil}.
+ */
+public class SalesforceBulkUtilTest {
+
+  private BulkConnection bulkConnection;
+  private JobInfo job;
+  private BatchInfo batchInfo;
+
+  @Before
+  public void setUp() {
+    // Create mock BulkConnection, JobInfo, and BatchInfo objects
+    bulkConnection = mock(BulkConnection.class);
+    job = mock(JobInfo.class);
+    batchInfo = mock(BatchInfo.class);
+    when(job.getId()).thenReturn("1");
+    when(job.getConcurrencyMode()).thenReturn(ConcurrencyMode.Parallel);
+    when(batchInfo.getId()).thenReturn("1");
+    when(batchInfo.getState()).thenReturn(BatchStateEnum.Completed);
+  }
+
+  @Test(expected = BulkAPIBatchException.class)
+  public void testAwaitCompletionBatchFailed() throws Exception {
+    when(batchInfo.getState()).thenReturn(BatchStateEnum.Failed);
+    BatchInfoList batchInfoList = mock(BatchInfoList.class);
+    BatchInfo[] batchInfoDetail = new BatchInfo[]{batchInfo};
+    when(bulkConnection.getBatchInfoList(job.getId())).thenReturn(batchInfoList);
+    when(batchInfoList.getBatchInfo()).thenReturn(batchInfoDetail);
+
+    // Call the awaitCompletion method and verify that it throws a BulkAPIBatchException when the batch fails
+    SalesforceBulkUtil.awaitCompletion(bulkConnection, job, Collections.singletonList(batchInfo), false);
+  }
+
+  @Test(expected = AsyncApiException.class)
+  public void testAwaitCompletionAsyncApiException() throws Exception {
+    when(bulkConnection.getBatchInfoList(job.getId())).thenThrow(
+      new AsyncApiException("Failed to get batch info list ", AsyncExceptionCode.ClientInputError));
+    // Call the awaitCompletion method and verify that it throws a AsyncApiException after retrying 10 times.
+    SalesforceBulkUtil.awaitCompletion(bulkConnection, job, Collections.singletonList(batchInfo), true);
+  }
+
+  @Test
+  public void testAwaitCompletionBatchCompleted() throws Exception {
+    when(batchInfo.getState()).thenReturn(BatchStateEnum.Completed);
+    BatchInfoList batchInfoList = mock(BatchInfoList.class);
+    BatchInfo[] batchInfoDetail = new BatchInfo[]{batchInfo};
+    when(bulkConnection.getBatchInfoList(job.getId())).thenReturn(batchInfoList);
+    when(batchInfoList.getBatchInfo()).thenReturn(batchInfoDetail);
+
+    // Call the awaitCompletion method and verify that it completes successfully
+    SalesforceBulkUtil.awaitCompletion(bulkConnection, job, Collections.singletonList(batchInfo), true);
+  }
+}


### PR DESCRIPTION
Increased the timeout for Bulk API jobs as some jobs were taking more time to complete. Added validation on sink side to test schema.
[PLUGIN-1545](https://cdap.atlassian.net/browse/PLUGIN-1545)

[PLUGIN-1545]: https://cdap.atlassian.net/browse/PLUGIN-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ