### PR TITLE
PLUGIN-1656 Added a field for datatype validation to avoid validation.

### DIFF
--- a/docs/Salesforce-batchsink.md
+++ b/docs/Salesforce-batchsink.md
@@ -104,6 +104,9 @@ This value cannot be greater than 10,000,000.
 Skip on error - Ignores erroneous records.  
 Fail on error - Fails pipeline due to erroneous record.
 
+**Data type Validation:** Whether to validate the field data types of the input schema as per Salesforce specific
+data types.
+
 Ingesting File and Attachment Data
 -----------
 The Salesforce Sink Plugin enables users to ingest file and attachment data, such as PDF and DOC files, into Salesforce

--- a/src/main/java/io/cdap/plugin/salesforce/SObjectsDescribeResult.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SObjectsDescribeResult.java
@@ -190,7 +190,7 @@ public class SObjectsDescribeResult {
     return result == null
       ? null
       : Stream.of(result.getFields())
-      .filter(field -> name.equals(field.getRelationshipName()))
+      .filter(field -> name.equalsIgnoreCase(field.getRelationshipName()))
       .findAny()
       .map(field -> field.getReferenceTo()[0]) // only first reference name will be used
       .orElse(null);
@@ -200,7 +200,7 @@ public class SObjectsDescribeResult {
     return result == null
       ? null
       : Stream.of(result.getChildRelationships())
-      .filter(childRelationship -> name.equals(childRelationship.getRelationshipName()))
+      .filter(childRelationship -> name.equalsIgnoreCase(childRelationship.getRelationshipName()))
       .findAny()
       .map(ChildRelationship::getChildSObject)
       .orElse(null);

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceSchemaUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceSchemaUtil.java
@@ -178,8 +178,8 @@ public class SalesforceSchemaUtil {
       if (!actualFieldSchema.equals(providedFieldSchema)
         || !Objects.equals(actualFieldSchema.getLogicalType(), providedFieldSchema.getLogicalType())) {
         throw new IllegalArgumentException(
-          String.format("Expected field '%s' to be of '%s', but it is of '%s'",
-            providedField.getName(), providedFieldSchema, actualFieldSchema));
+          String.format("Expected field '%s' to be of %s, but it is of %s",
+                        providedField.getName(), providedFieldSchema, actualFieldSchema));
       }
 
       if (checkNullable && isActualFieldNullable && !isProvidedFieldNullable) {

--- a/src/test/java/io/cdap/plugin/salesforce/connector/SalesforceConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/connector/SalesforceConnectorTest.java
@@ -96,6 +96,6 @@ public class SalesforceConnectorTest {
       "\"null\"]},{\"name\":\"userId\",\"type\":\"string\"}]}";
 
     return Schema.parseJson(schemaString);
-
   }
+
 }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
@@ -231,6 +231,6 @@ public abstract class BaseSalesforceBatchSinkETLTest extends BaseSalesforceETLTe
                                     BaseSalesforceETLTest.LOGIN_URL, 30000, sObject, "Insert", null,
                                     ConcurrencyMode.Parallel.name(), "1000000", "10000", "Fail on Error",
                                     BaseSalesforceETLTest.SECURITY_TOKEN,
-                                    null, null);
+                                    null, null, false);
   }
 }

--- a/widgets/Salesforce-batchsink.json
+++ b/widgets/Salesforce-batchsink.json
@@ -193,6 +193,22 @@
             ],
             "default": "Skip on error"
           }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Data type Validation",
+          "name": "datatypeValidation",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "true"
+          }
         }
       ]
     }


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-1656
Added a field for datatype validation to avoid validation in Salesforce sink plugin. E.g. some existing users are providing date fields as a string in input schema and same was not getting validated and this process was working fine as while creating csv file these string were getting used as it as.  We added validation on data types to avoid any wrong value in such fields but customer wants to use existing approach. So, we have added a flag datatype validation which will be false by default so that it will not impact existing users.