### PR TITLE
PLUGIN-1665 fix oauthInfo property

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -88,7 +88,7 @@ public class SalesforceConnectionUtil {
    * @param collector  FailureCollector
    * @return           OAuthInfo which contains Access Token and login URL.
    */
-  public static OAuthInfo getOAuthInfo(SalesforceConnectorConfig config, FailureCollector collector) {
+  public static OAuthInfo getOAuthInfo(SalesforceConnectorInfo config, FailureCollector collector) {
     if (!config.canAttemptToEstablishConnection()) {
       return null;
     }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/OAuthInfo.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/OAuthInfo.java
@@ -16,10 +16,12 @@
 
 package io.cdap.plugin.salesforce.plugin;
 
+import java.io.Serializable;
+
 /**
  * Class to carry OAuth information returned by the {@code ${oauth}} macro function.
  */
-public final class OAuthInfo {
+public final class OAuthInfo implements Serializable {
 
   private final String accessToken;
   private final String instanceURL;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * Base configuration for Salesforce Streaming and Batch plugins
  */
-public class SalesforceConnectorConfig extends PluginConfig {
+public class SalesforceConnectorBaseConfig extends PluginConfig {
 
   @Nullable
   @Name(SalesforceConstants.PROPERTY_PROXY_URL)
@@ -44,60 +44,50 @@ public class SalesforceConnectorConfig extends PluginConfig {
   @Nullable
   private final Integer connectTimeout;
 
-  @Name(SalesforceConstants.PROPERTY_OAUTH_INFO)
-  @Description("OAuth information for connecting to Salesforce. " +
-    "It is expected to be an json string containing two properties, \"accessToken\" and \"instanceURL\", " +
-    "which carry the OAuth access token and the URL to connect to respectively. " +
-    "Use the ${oauth(provider, credentialId)} macro function for acquiring OAuth information dynamically. ")
-  @Macro
-  @Nullable
-  private OAuthInfo oAuthInfo;
-
   @Name(SalesforceConstants.PROPERTY_CONSUMER_KEY)
   @Description("Salesforce connected app's consumer key")
   @Macro
   @Nullable
-  private String consumerKey;
+  private final String consumerKey;
 
   @Name(SalesforceConstants.PROPERTY_CONSUMER_SECRET)
   @Description("Salesforce connected app's client secret key")
   @Macro
   @Nullable
-  private String consumerSecret;
+  private final String consumerSecret;
 
   @Name(SalesforceConstants.PROPERTY_USERNAME)
   @Description("Salesforce username")
   @Macro
   @Nullable
-  private String username;
+  private final String username;
 
   @Name(SalesforceConstants.PROPERTY_PASSWORD)
   @Description("Salesforce password")
   @Macro
   @Nullable
-  private String password;
+  private final String password;
 
   @Name(SalesforceConstants.PROPERTY_SECURITY_TOKEN)
   @Description("Salesforce security token")
   @Macro
   @Nullable
-  private String securityToken;
-  
+  private final String securityToken;
+
   @Name(SalesforceConstants.PROPERTY_LOGIN_URL)
   @Description("Endpoint to authenticate to")
   @Macro
   @Nullable
-  private String loginUrl;
+  private final String loginUrl;
 
-  public SalesforceConnectorConfig(@Nullable String consumerKey,
-                                   @Nullable String consumerSecret,
-                                   @Nullable String username,
-                                   @Nullable String password,
-                                   @Nullable String loginUrl,
-                                   @Nullable String securityToken,
-                                   @Nullable Integer connectTimeout,
-                                   @Nullable OAuthInfo oAuthInfo,
-                                   @Nullable String proxyUrl) {
+  public SalesforceConnectorBaseConfig(@Nullable String consumerKey,
+                                       @Nullable String consumerSecret,
+                                       @Nullable String username,
+                                       @Nullable String password,
+                                       @Nullable String loginUrl,
+                                       @Nullable String securityToken,
+                                       @Nullable Integer connectTimeout,
+                                       @Nullable String proxyUrl) {
     this.consumerKey = consumerKey;
     this.consumerSecret = consumerSecret;
     this.username = username;
@@ -105,13 +95,7 @@ public class SalesforceConnectorConfig extends PluginConfig {
     this.loginUrl = loginUrl;
     this.securityToken = securityToken;
     this.connectTimeout = connectTimeout;
-    this.oAuthInfo = oAuthInfo;
     this.proxyUrl = proxyUrl;
-  }
-
-  @Nullable
-  public OAuthInfo getOAuthInfo() {
-    return oAuthInfo;
   }
 
   @Nullable
@@ -156,43 +140,6 @@ public class SalesforceConnectorConfig extends PluginConfig {
         .withStacktrace(e.getStackTrace());
     }
     collector.getOrThrowException();
-  }
-
-  public AuthenticatorCredentials getAuthenticatorCredentials() {
-    OAuthInfo oAuthInfo = getOAuthInfo();
-    if (oAuthInfo != null) {
-      return new AuthenticatorCredentials(oAuthInfo, getConnectTimeout(),
-                                          getProxyUrl());
-    }
-    return new AuthenticatorCredentials(getUsername(), getPassword(), getConsumerKey(),
-                                        getConsumerSecret(), getLoginUrl(), getConnectTimeout(),
-                                        getProxyUrl());
-  }
-
-  /**
-   * Checks if current config does not contain macro for properties which are used
-   * to establish connection to Salesforce.
-   *
-   * @return true if none of the connection properties contains macro, false otherwise
-   */
-  public boolean canAttemptToEstablishConnection() {
-    // If OAuth token is configured, use it to establish connection
-    if (getOAuthInfo() != null) {
-      return true;
-    }
-
-    // At configurePipeline time, macro is not resolved, hence the OAuth field will be null.
-    if (containsMacro(SalesforceConstants.PROPERTY_OAUTH_INFO)) {
-      return false;
-    }
-
-    return !(containsMacro(SalesforceConstants.PROPERTY_CONSUMER_KEY)
-      || containsMacro(SalesforceConstants.PROPERTY_CONSUMER_SECRET)
-      || containsMacro(SalesforceConstants.PROPERTY_USERNAME)
-      || containsMacro(SalesforceConstants.PROPERTY_PASSWORD)
-      || containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL)
-      || containsMacro(SalesforceConstants.PROPERTY_SECURITY_TOKEN)
-      || containsMacro(SalesforceConstants.PROPERTY_CONNECT_TIMEOUT));
   }
 
   private void validateConnection(@Nullable OAuthInfo oAuthInfo) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce.plugin;
+
+import com.sforce.ws.ConnectionException;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
+import io.cdap.plugin.salesforce.SalesforceConstants;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Common logic and configuration for Connector, Source, and Sink plugins. This class exists because the
+ * {@link SalesforceConnectorConfig} cannot be used directly in Source and Sink configs because plugin configs
+ * cannot contain an object (OAuthInfo) within an object (SalesforceConnectorConfig).
+ */
+public class SalesforceConnectorInfo {
+  private final OAuthInfo oAuthInfo;
+  private final SalesforceConnectorBaseConfig config;
+
+  public SalesforceConnectorInfo(@Nullable OAuthInfo oAuthInfo, SalesforceConnectorBaseConfig config) {
+    this.oAuthInfo = oAuthInfo;
+    this.config = config;
+  }
+
+  @Nullable
+  public OAuthInfo getOAuthInfo() {
+    return oAuthInfo;
+  }
+
+  @Nullable
+  public String getConsumerKey() {
+    return config.getConsumerKey();
+  }
+
+  @Nullable
+  public String getConsumerSecret() {
+    return config.getConsumerSecret();
+  }
+
+  @Nullable
+  public String getUsername() {
+    return config.getUsername();
+  }
+
+  @Nullable
+  public String getPassword() {
+    return config.getPassword();
+  }
+
+  @Nullable
+  public String getLoginUrl() {
+    return config.getLoginUrl();
+  }
+
+  @Nullable
+  public Integer getConnectTimeout() {
+    return config.getConnectTimeout();
+  }
+
+  @Nullable
+  public String getProxyUrl() {
+    return config.getProxyUrl();
+  }
+
+  public void validate(FailureCollector collector, @Nullable OAuthInfo oAuthInfo) {
+    try {
+      validateConnection(oAuthInfo);
+    } catch (Exception e) {
+      collector.addFailure("Error encountered while establishing connection: " + e.getMessage(),
+                           "Please verify authentication properties are provided correctly")
+        .withStacktrace(e.getStackTrace());
+    }
+    collector.getOrThrowException();
+  }
+
+  public AuthenticatorCredentials getAuthenticatorCredentials() {
+    OAuthInfo oAuthInfo = getOAuthInfo();
+    if (oAuthInfo != null) {
+      return new AuthenticatorCredentials(oAuthInfo, config.getConnectTimeout(),
+                                          config.getProxyUrl());
+    }
+    return new AuthenticatorCredentials(config.getUsername(), config.getPassword(), config.getConsumerKey(),
+                                        config.getConsumerSecret(), config.getLoginUrl(), config.getConnectTimeout(),
+                                        config.getProxyUrl());
+  }
+
+  /**
+   * Checks if current config does not contain macro for properties which are used
+   * to establish connection to Salesforce.
+   *
+   * @return true if none of the connection properties contains macro, false otherwise
+   */
+  public boolean canAttemptToEstablishConnection() {
+    // If OAuth token is configured, use it to establish connection
+    if (getOAuthInfo() != null) {
+      return true;
+    }
+
+    // At configurePipeline time, macro is not resolved, hence the OAuth field will be null.
+    if (config.containsMacro(SalesforceConstants.PROPERTY_OAUTH_INFO)) {
+      return false;
+    }
+
+    return !(config.containsMacro(SalesforceConstants.PROPERTY_CONSUMER_KEY)
+      || config.containsMacro(SalesforceConstants.PROPERTY_CONSUMER_SECRET)
+      || config.containsMacro(SalesforceConstants.PROPERTY_USERNAME)
+      || config.containsMacro(SalesforceConstants.PROPERTY_PASSWORD)
+      || config.containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL)
+      || config.containsMacro(SalesforceConstants.PROPERTY_SECURITY_TOKEN)
+      || config.containsMacro(SalesforceConstants.PROPERTY_CONNECT_TIMEOUT));
+  }
+
+  private void validateConnection(@Nullable OAuthInfo oAuthInfo) {
+    if (oAuthInfo == null) {
+      return;
+    }
+
+    try {
+      SalesforceConnectionUtil.getPartnerConnection(new AuthenticatorCredentials(oAuthInfo, config.getConnectTimeout(),
+                                                                                 config.getProxyUrl()));
+    } catch (ConnectionException e) {
+      String message = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
+      throw new RuntimeException(
+        String.format("Failed to establish and validate connection to salesforce: %s", message), e);
+    }
+  }
+}

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.cdap.plugin.salesforce.connector;
+package io.cdap.plugin.salesforce.plugin.connector;
 
 import com.sforce.async.AsyncApiException;
 import com.sforce.soap.partner.DescribeGlobalResult;
@@ -48,7 +48,7 @@ import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
 import io.cdap.plugin.salesforce.plugin.sink.batch.SalesforceBatchSink;
 import io.cdap.plugin.salesforce.plugin.sink.batch.SalesforceSinkConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.MapToRecordTransformer;
@@ -81,8 +81,9 @@ public class SalesforceConnector implements DirectConnector {
   @Override
   public void test(ConnectorContext connectorContext) throws ValidationException {
     FailureCollector collector = connectorContext.getFailureCollector();
-    OAuthInfo oAuthInfo = SalesforceConnectionUtil.getOAuthInfo(config, collector);
-    config.validate(collector, oAuthInfo);
+    SalesforceConnectorInfo connectorInfo = new SalesforceConnectorInfo(config.getOAuthInfo(), config);
+    OAuthInfo oAuthInfo = SalesforceConnectionUtil.getOAuthInfo(connectorInfo, collector);
+    connectorInfo.validate(collector, oAuthInfo);
   }
 
   @Override
@@ -138,9 +139,10 @@ public class SalesforceConnector implements DirectConnector {
       properties.put(SalesforceSourceConstants.PROPERTY_SOBJECT_NAME, tableName);
       properties.put(SalesforceSinkConfig.PROPERTY_SOBJECT, tableName);
     }
-    AuthenticatorCredentials authenticatorCredentials = config.getAuthenticatorCredentials();
+    SalesforceConnectorInfo connectorInfo = new SalesforceConnectorInfo(config.getOAuthInfo(), config);
+    AuthenticatorCredentials authenticatorCredentials = connectorInfo.getAuthenticatorCredentials();
     try {
-      String fields = getObjectFields(tableName);
+      String fields = getObjectFields(tableName, authenticatorCredentials);
       String query = String.format("SELECT %s FROM %s", fields, tableName);
       SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
       Schema schema = SalesforceSchemaUtil.getSchema(authenticatorCredentials, sObjectDescriptor);
@@ -172,13 +174,9 @@ public class SalesforceConnector implements DirectConnector {
   private List<StructuredRecord> listObjectDetails(String object, int limit) throws AsyncApiException,
     ConnectionException {
     List<StructuredRecord> samples = new ArrayList<>();
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(config.getUsername(), config.getPassword(),
-                                                                        config.getConsumerKey(),
-                                                                        config.getConsumerSecret(),
-                                                                        config.getLoginUrl(),
-                                                                        config.getConnectTimeout(),
-                                                                        config.getProxyUrl());
-    String fields = getObjectFields(object);
+    SalesforceConnectorInfo connectorInfo = new SalesforceConnectorInfo(config.getOAuthInfo(), config);
+    AuthenticatorCredentials credentials = connectorInfo.getAuthenticatorCredentials();
+    String fields = getObjectFields(object, credentials);
     String query = String.format("SELECT %s FROM %s LIMIT %d", fields, object, limit);
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     SoapRecordToMapTransformer soapRecordToMapTransformer = new SoapRecordToMapTransformer();
@@ -195,8 +193,8 @@ public class SalesforceConnector implements DirectConnector {
     return samples;
   }
 
-  private String getObjectFields(String object) throws ConnectionException {
-    SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(object, config.getAuthenticatorCredentials(),
+  private String getObjectFields(String object, AuthenticatorCredentials credentials) throws ConnectionException {
+    SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(object, credentials,
                                                                      SalesforceSchemaUtil.COMPOUND_FIELDS);
     List<String> actualFields = sObjectDescriptor.getFieldsNames();
     String result = String.join(",", actualFields);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnectorConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnectorConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce.plugin.connector;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.plugin.salesforce.SalesforceConstants;
+import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorBaseConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Base configuration for Salesforce Streaming and Batch plugins
+ */
+public class SalesforceConnectorConfig extends SalesforceConnectorBaseConfig {
+
+  @Name(SalesforceConstants.PROPERTY_OAUTH_INFO)
+  @Description("OAuth information for connecting to Salesforce. " +
+    "It is expected to be an json string containing two properties, \"accessToken\" and \"instanceURL\", " +
+    "which carry the OAuth access token and the URL to connect to respectively. " +
+    "Use the ${oauth(provider, credentialId)} macro function for acquiring OAuth information dynamically. ")
+  @Macro
+  @Nullable
+  private OAuthInfo oAuthInfo;
+
+  public SalesforceConnectorConfig(@Nullable String consumerKey,
+                                   @Nullable String consumerSecret,
+                                   @Nullable String username,
+                                   @Nullable String password,
+                                   @Nullable String loginUrl,
+                                   @Nullable String securityToken,
+                                   @Nullable Integer connectTimeout,
+                                   @Nullable OAuthInfo oAuthInfo,
+                                   @Nullable String proxyUrl) {
+    super(consumerKey, consumerSecret, username, password, loginUrl, securityToken, connectTimeout, proxyUrl);
+    this.oAuthInfo = oAuthInfo;
+  }
+
+  @Nullable
+  public OAuthInfo getOAuthInfo() {
+    return oAuthInfo;
+  }
+}

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -36,7 +36,9 @@ import io.cdap.plugin.salesforce.SalesforceQueryUtil;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorBaseConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -100,7 +102,16 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
   @Macro
   @Nullable
   @Description("The existing connection to use.")
-  private SalesforceConnectorConfig connection;
+  private SalesforceConnectorBaseConfig connection;
+
+  @Name(SalesforceConstants.PROPERTY_OAUTH_INFO)
+  @Description("OAuth information for connecting to Salesforce. " +
+    "It is expected to be an json string containing two properties, \"accessToken\" and \"instanceURL\", " +
+    "which carry the OAuth access token and the URL to connect to respectively. " +
+    "Use the ${oauth(provider, credentialId)} macro function for acquiring OAuth information dynamically. ")
+  @Macro
+  @Nullable
+  private OAuthInfo oAuthInfo;
 
   protected SalesforceBaseSourceConfig(String referenceName,
                                        @Nullable String consumerKey,
@@ -137,8 +148,8 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
   }
 
   @Nullable
-  public SalesforceConnectorConfig getConnection() {
-    return connection;
+  public SalesforceConnectorInfo getConnection() {
+    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection);
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -38,7 +38,9 @@ import io.cdap.plugin.salesforce.SalesforceQueryUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorBaseConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import io.cdap.plugin.salesforce.soap.SObjectBuilder;
 import io.cdap.plugin.salesforce.soap.SObjectUtil;
@@ -105,7 +107,16 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
   @Macro
   @Nullable
   @Description("The existing connection to use.")
-  private SalesforceConnectorConfig connection;
+  private SalesforceConnectorBaseConfig connection;
+
+  @Name(SalesforceConstants.PROPERTY_OAUTH_INFO)
+  @Description("OAuth information for connecting to Salesforce. " +
+    "It is expected to be an json string containing two properties, \"accessToken\" and \"instanceURL\", " +
+    "which carry the OAuth access token and the URL to connect to respectively. " +
+    "Use the ${oauth(provider, credentialId)} macro function for acquiring OAuth information dynamically. ")
+  @Macro
+  @Nullable
+  private OAuthInfo oAuthInfo;
 
   @Description("Push topic property, which specifies how the record is evaluated against the PushTopic query.\n" +
     "The NotifyForFields values are:\n" +
@@ -148,8 +159,8 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
   }
 
   @Nullable
-  public SalesforceConnectorConfig getConnection() {
-    return connection;
+  public SalesforceConnectorInfo getConnection() {
+    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection);
   }
 
   public String getPushTopicName() {
@@ -359,6 +370,7 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
 
   @Nullable
   private String getSObjectQuery() {
+    SalesforceConnectorInfo connection = getConnection();
     if (!connection.canAttemptToEstablishConnection()) {
       return null;
     }

--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
@@ -21,7 +21,8 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.sink.batch.CSVRecord;
 import io.cdap.plugin.salesforce.plugin.sink.batch.FileUploadSobject;
 import io.cdap.plugin.salesforce.plugin.sink.batch.StructuredRecordToCSVRecordTransformer;
@@ -266,7 +267,7 @@ public class SalesforceSchemaUtilTest {
     SalesforceSourceConfig mockConfig = Mockito.mock(SalesforceSourceConfig.class);
     MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(null);
     SalesforceBatchSource source = new SalesforceBatchSource(mockConfig);
-    SalesforceConnectorConfig mockConnection = Mockito.mock(SalesforceConnectorConfig.class);
+    SalesforceConnectorInfo mockConnection = Mockito.mock(SalesforceConnectorInfo.class);
     Mockito.when(mockConfig.getConnection()).thenReturn(mockConnection);
     Mockito.when(mockConfig.getConnection().canAttemptToEstablishConnection()).thenReturn(false);
     Mockito.when(mockConfig.getSchema()).thenReturn(schema);
@@ -283,7 +284,7 @@ public class SalesforceSchemaUtilTest {
     SalesforceStreamingSourceConfig mockConfig = Mockito.mock(SalesforceStreamingSourceConfig.class);
     MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(null);
     SalesforceStreamingSource source = new SalesforceStreamingSource(mockConfig);
-    SalesforceConnectorConfig mockConnection = Mockito.mock(SalesforceConnectorConfig.class);
+    SalesforceConnectorInfo mockConnection = Mockito.mock(SalesforceConnectorInfo.class);
     Mockito.when(mockConfig.getConnection()).thenReturn(mockConnection);
     mockConfig.referenceName = "TestStreaming";
     Mockito.when(mockConfig.getConnection().canAttemptToEstablishConnection()).thenReturn(false);
@@ -299,7 +300,7 @@ public class SalesforceSchemaUtilTest {
     MockPipelineConfigurer mockPipelineConfigurer = new MockPipelineConfigurer(null);
     SalesforceBatchMultiSource source = new SalesforceBatchMultiSource(mockConfig);
     mockConfig.referenceName = "TestStreaming";
-    SalesforceConnectorConfig mockConnection = Mockito.mock(SalesforceConnectorConfig.class);
+    SalesforceConnectorInfo mockConnection = Mockito.mock(SalesforceConnectorInfo.class);
     Mockito.when(mockConfig.getConnection()).thenReturn(mockConnection);
     Mockito.when(mockConfig.getConnection().canAttemptToEstablishConnection()).thenReturn(false);
     source.configurePipeline(mockPipelineConfigurer);

--- a/src/test/java/io/cdap/plugin/salesforce/connector/SalesforceConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/connector/SalesforceConnectorTest.java
@@ -28,7 +28,9 @@ import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.salesforce.SObjectDescriptor;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnector;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource;
 import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceSourceConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceSourceConfigBuilder;
@@ -57,8 +59,8 @@ public class SalesforceConnectorTest {
       .setChunkSize(SalesforceSourceConstants.MIN_PK_CHUNK_SIZE)
       .setReferenceName("Source").setSObjectName("object").build();
     SalesforceConnectorConfig connectorConfig = Mockito.mock(SalesforceConnectorConfig.class);
+    Mockito.when(connectorConfig.getOAuthInfo()).thenReturn(new OAuthInfo("accessToken", "instanceURL"));
     MockFailureCollector collector = new MockFailureCollector();
-    Mockito.when(connectorConfig.canAttemptToEstablishConnection()).thenReturn(false);
     ConnectorContext context = new MockConnectorContext(new MockConnectorConfigurer());
     SalesforceConnector connector = new SalesforceConnector(connectorConfig);
     try {

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
@@ -21,7 +21,8 @@ import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.salesforce.InvalidConfigException;
-import io.cdap.plugin.salesforce.plugin.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
+import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -228,9 +229,9 @@ public class SalesforceSourceConfigTest {
     testValidPKChunkConfiguration(config.getConnection());
   }
 
-  private void testValidPKChunkConfiguration(SalesforceConnectorConfig config) {
+  private void testValidPKChunkConfiguration(SalesforceConnectorInfo config) {
     MockFailureCollector collector = new MockFailureCollector();
-    SalesforceConnectorConfig mock = Mockito.spy(config);
+    SalesforceConnectorInfo mock = Mockito.spy(config);
     Mockito.when(mock.canAttemptToEstablishConnection()).thenReturn(false);
     mock.validate(collector, null);
     Assert.assertEquals(0, collector.getValidationFailures().size());
@@ -276,8 +277,9 @@ public class SalesforceSourceConfigTest {
                                                                         Mockito.any(), Mockito.any(),
                                                                         Mockito.anyString())
       .thenReturn(connectorConfig);
-    Mockito.when(mock.getConnection()).thenReturn(connectorConfig);
-    PowerMockito.when(connectorConfig.canAttemptToEstablishConnection()).thenReturn(false);
+    SalesforceConnectorInfo salesforceConnectorInfo = new SalesforceConnectorInfo(null, connectorConfig);
+    Mockito.when(mock.getConnection()).thenReturn(salesforceConnectorInfo);
+    PowerMockito.when(salesforceConnectorInfo.canAttemptToEstablishConnection()).thenReturn(false);
     ValidationFailure failure;
     try {
       mock.validate(collector, null);


### PR DESCRIPTION
Fix usage of the oauthInfo plugin property. CDAP does not allow objects within objects in a PluginConfig. This was preventing the plugins from getting instantiated whenever the oauthInfo macro was being used.

Refactored classes to pull OAuthInfo into top level fields in each plugin config. Introduced a SalesforceConnectorInfo class that contains logic that used to be in the SalesforceConnectorConfig class, and changed the various plugin configs to return this new ConnectorInfo class instead of the ConnectorConfig class.