### PR TITLE
[PLUGIN-1720] Fix Added for Non nullable properties of reference or child objects

### DIFF
--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
@@ -22,7 +22,6 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
-import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.sink.batch.CSVRecord;
 import io.cdap.plugin.salesforce.plugin.sink.batch.FileUploadSobject;
 import io.cdap.plugin.salesforce.plugin.sink.batch.StructuredRecordToCSVRecordTransformer;
@@ -124,29 +123,42 @@ public class SalesforceSchemaUtilTest {
 
     Schema actualSchema = SalesforceSchemaUtil.getSchemaWithFields(sObjectDescriptor, describeResult);
 
-    Schema expectedSchema = Schema.recordOf("output",
-      Schema.Field.of("Id", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("Amount", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("Percent", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("ConversionRate", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("IsWon", Schema.of(Schema.Type.BOOLEAN)),
-      Schema.Field.of("CreatedDate", Schema.of(Schema.LogicalType.DATE)),
-      Schema.Field.of("CreatedDateTime", Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
-      Schema.Field.of("CreatedTime", Schema.of(Schema.LogicalType.TIME_MICROS)),
-      Schema.Field.of("Account_NumberOfEmployees", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("IdAlias", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("Cnt", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("Mx", Schema.of(Schema.LogicalType.DATE)),
-      Schema.Field.of("DayOnlyFunc", Schema.of(Schema.LogicalType.DATE)),
-      Schema.Field.of("GroupingFunc", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("AvgFunc", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("CalMonFunc", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("SumFunc", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-      Schema.Field.of("SumRelFunc", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of(contacts, Schema.arrayOf(Schema.recordOf(contacts,
-        Schema.Field.of("FirstName", Schema.of(Schema.Type.STRING)),
-        Schema.Field.of("Owner_Status", Schema.of(Schema.Type.STRING))))));
+    Schema expectedSchema =
+      Schema.recordOf("output",
+                      Schema.Field.of("Id", Schema.of(Schema.Type.LONG)),
+                      Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
+                      Schema.Field.of("Amount", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                      Schema.Field.of("Percent",
+                                      Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                      Schema.Field.of("ConversionRate",
+                                      Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                      Schema.Field.of("IsWon", Schema.of(Schema.Type.BOOLEAN)),
+                      Schema.Field.of("CreatedDate", Schema.of(Schema.LogicalType.DATE)),
+                      Schema.Field.of("CreatedDateTime",
+                                      Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)),
+                      Schema.Field.of("CreatedTime", Schema.of(Schema.LogicalType.TIME_MICROS)),
+                      Schema.Field.of("Account_NumberOfEmployees",
+                                      Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                      Schema.Field.of("IdAlias", Schema.of(Schema.Type.LONG)),
+                      Schema.Field.of("Cnt", Schema.of(Schema.Type.LONG)),
+                      Schema.Field.of("Mx", Schema.of(Schema.LogicalType.DATE)),
+                      Schema.Field.of("DayOnlyFunc", Schema.of(Schema.LogicalType.DATE)),
+                      Schema.Field.of("GroupingFunc", Schema.of(Schema.Type.INT)),
+                      Schema.Field.of("AvgFunc",
+                                      Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                      Schema.Field.of("CalMonFunc", Schema.of(Schema.Type.INT)),
+                      Schema.Field.of("SumFunc",
+                                      Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                      Schema.Field.of("SumRelFunc",
+                                      Schema.nullableOf(Schema.of(Schema.Type.LONG))),
+                      Schema.Field.of(contacts,
+                                      Schema.arrayOf(Schema.recordOf(contacts,
+                                                                     Schema.Field.of("FirstName", Schema.of(
+                                                                       Schema.Type.STRING)),
+                                                                     Schema.Field.of("Owner_Status",
+                                                                                     Schema.nullableOf(
+                                                                                       Schema.of(
+                                                                                         Schema.Type.STRING)))))));
 
     Assert.assertEquals(expectedSchema, actualSchema);
 


### PR DESCRIPTION
Salesforce Batch Source plugin cannot handle null values for timestamp-micros.

While using referenced object in the schema, for its child fields we were getting schema from the object itself, e.g. contact.account_lastmodifieddate, here it is returning lastmodifieddate as non nullable as per its value in account sobject. But if the account object itself is null in the source sobject, this value will definitely be null.
As a solution, setting up the child fields as non nullable to avoid this confusion