### PR TITLE
[cherrypick]oAuth issue, decimal and date time support in sink, Error logging 

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
@@ -38,9 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -120,23 +118,20 @@ public final class SalesforceBulkUtil {
        */
       CSVReader rdr = new CSVReader(bulkConnection.getBatchResultStream(job.getId(), batchInfo.getId()));
       List<String> resultHeader = rdr.nextRecord();
-      int resultCols = resultHeader.size();
+      int successRowId = resultHeader.indexOf("Success");
+      int errorRowId = resultHeader.indexOf("Error");
 
       List<String> row;
       while ((row = rdr.nextRecord()) != null) {
-        Map<String, String> resultInfo = new HashMap<>();
-        for (int i = 0; i < resultCols; i++) {
-          resultInfo.put(resultHeader.get(i), row.get(i));
-        }
-        boolean success = Boolean.parseBoolean(resultInfo.get("Success"));
+        boolean success = Boolean.parseBoolean(row.get(successRowId));
         if (!success) {
-          String error = resultInfo.get("Error");
+          String error = row.get(errorRowId);
           String errorMessage = String.format("Failed to create row with error: '%s'. BatchId='%s'",
                                               error, batchInfo.getId());
           if (ignoreFailures) {
             LOG.error(errorMessage);
           } else {
-            throw new RuntimeException(errorMessage);
+            throw new BulkAPIBatchException(errorMessage, batchInfo);
           }
         }
       }
@@ -181,6 +176,12 @@ public final class SalesforceBulkUtil {
                 throw new BulkAPIBatchException("Batch failed", b);
               }
             } else if (b.getState() == BatchStateEnum.Completed) {
+              LOG.debug("Batch Completed with Batch Id:{}, Total Processed Records: {}, Failed Records: {}," +
+                          " Successful records: {}",
+                        b.getId(),
+                        b.getNumberRecordsProcessed(),
+                        b.getNumberRecordsFailed(),
+                        b.getNumberRecordsProcessed() - b.getNumberRecordsFailed());
               incomplete.remove(b.getId());
             }
           }

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -15,6 +15,10 @@
  */
 package io.cdap.plugin.salesforce;
 
+import io.cdap.cdap.api.plugin.PluginConfig;
+
+import java.util.function.Function;
+
 /**
  * Constants related to Salesforce and configuration
  */
@@ -56,4 +60,7 @@ public class SalesforceConstants {
 
   public static final String PROPERTY_MAX_RETRY_TIME_IN_MINS = "cdap.streaming.maxRetryTimeInMins";
   public static final long DEFAULT_MAX_RETRY_TIME_IN_MINS = 360L;
+
+  public static Function<PluginConfig, Boolean> isOAuthMacroFunction = config -> config.containsMacro(
+    PROPERTY_OAUTH_INFO);
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
@@ -33,9 +33,13 @@ public class SalesforceConnectorInfo {
   private final OAuthInfo oAuthInfo;
   private final SalesforceConnectorBaseConfig config;
 
-  public SalesforceConnectorInfo(@Nullable OAuthInfo oAuthInfo, SalesforceConnectorBaseConfig config) {
+  private final boolean isOAuthInfoMacro;
+
+  public SalesforceConnectorInfo(@Nullable OAuthInfo oAuthInfo, SalesforceConnectorBaseConfig config,
+                                 boolean isOAuthInfoMacro) {
     this.oAuthInfo = oAuthInfo;
     this.config = config;
+    this.isOAuthInfoMacro = isOAuthInfoMacro;
   }
 
   @Nullable
@@ -118,7 +122,7 @@ public class SalesforceConnectorInfo {
     }
 
     // At configurePipeline time, macro is not resolved, hence the OAuth field will be null.
-    if (config.containsMacro(SalesforceConstants.PROPERTY_OAUTH_INFO)) {
+    if (isOAuthInfoMacro) {
       return false;
     }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
@@ -81,7 +81,10 @@ public class SalesforceConnector implements DirectConnector {
   @Override
   public void test(ConnectorContext connectorContext) throws ValidationException {
     FailureCollector collector = connectorContext.getFailureCollector();
-    SalesforceConnectorInfo connectorInfo = new SalesforceConnectorInfo(config.getOAuthInfo(), config);
+    SalesforceConnectorInfo connectorInfo =
+      new SalesforceConnectorInfo(config.getOAuthInfo(), config,
+                                  SalesforceConstants.isOAuthMacroFunction.apply(
+                                    config));
     OAuthInfo oAuthInfo = SalesforceConnectionUtil.getOAuthInfo(connectorInfo, collector);
     connectorInfo.validate(collector, oAuthInfo);
   }
@@ -130,7 +133,10 @@ public class SalesforceConnector implements DirectConnector {
       properties.put(SalesforceSourceConstants.PROPERTY_SOBJECT_NAME, tableName);
       properties.put(SalesforceSinkConfig.PROPERTY_SOBJECT, tableName);
     }
-    SalesforceConnectorInfo connectorInfo = new SalesforceConnectorInfo(config.getOAuthInfo(), config);
+    SalesforceConnectorInfo connectorInfo =
+      new SalesforceConnectorInfo(config.getOAuthInfo(), config,
+                                  SalesforceConstants.isOAuthMacroFunction.apply(
+                                    config));
     AuthenticatorCredentials authenticatorCredentials = connectorInfo.getAuthenticatorCredentials();
     try {
       String fields = getObjectFields(tableName, authenticatorCredentials);
@@ -165,7 +171,10 @@ public class SalesforceConnector implements DirectConnector {
   private List<StructuredRecord> listObjectDetails(String object, int limit) throws AsyncApiException,
     ConnectionException {
     List<StructuredRecord> samples = new ArrayList<>();
-    SalesforceConnectorInfo connectorInfo = new SalesforceConnectorInfo(config.getOAuthInfo(), config);
+    SalesforceConnectorInfo connectorInfo =
+      new SalesforceConnectorInfo(config.getOAuthInfo(), config,
+                                  SalesforceConstants.isOAuthMacroFunction.apply(
+                                    config));
     AuthenticatorCredentials credentials = connectorInfo.getAuthenticatorCredentials();
     String fields = getObjectFields(object, credentials);
     String query = String.format("SELECT %s FROM %s LIMIT %d", fields, object, limit);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
@@ -185,7 +185,9 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
 
   @Nullable
   public SalesforceConnectorInfo getConnection() {
-    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection);
+    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection,
+                                                                   SalesforceConstants.isOAuthMacroFunction.apply(
+                                                                     this));
   }
 
   public String getSObject() {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -182,7 +182,9 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
 
   @Nullable
   public SalesforceConnectorInfo getConnection() {
-    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection);
+    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection,
+                                                                   SalesforceConstants.isOAuthMacroFunction.apply(
+                                                                     this));
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -83,7 +83,8 @@ public class SalesforceBatchSource extends
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     FailureCollector collector = pipelineConfigurer.getStageConfigurer().getFailureCollector();
 
-    OAuthInfo oAuthInfo = SalesforceConnectionUtil.getOAuthInfo(config.getConnection(), collector);
+    OAuthInfo oAuthInfo = config.containsMacro(SalesforceConstants.PROPERTY_OAUTH_INFO)
+      ? null : SalesforceConnectionUtil.getOAuthInfo(config.getConnection(), collector);
     config.validate(collector, oAuthInfo);
 
     if (config.containsMacro(SalesforceSourceConstants.PROPERTY_SCHEMA)) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -161,7 +161,9 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
 
   @Nullable
   public SalesforceConnectorInfo getConnection() {
-    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection);
+    return connection == null ? null : new SalesforceConnectorInfo(oAuthInfo, connection,
+                                                                   SalesforceConstants.isOAuthMacroFunction.apply(
+                                                                     this));
   }
 
   public String getPushTopicName() {

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/sink/batch/StructuredRecordToCSVRecordTransformerTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/sink/batch/StructuredRecordToCSVRecordTransformerTest.java
@@ -20,6 +20,8 @@ import io.cdap.cdap.api.data.schema.Schema;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+
 public class StructuredRecordToCSVRecordTransformerTest {
 
   @Test
@@ -31,8 +33,9 @@ public class StructuredRecordToCSVRecordTransformerTest {
       Schema.Field.of("time_micros_field", Schema.of(Schema.LogicalType.TIME_MICROS)),
       Schema.Field.of("timestamp_millis_field", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
       Schema.Field.of("time_millis_field", Schema.of(Schema.LogicalType.TIME_MILLIS)),
-      Schema.Field.of("string_field", Schema.of(Schema.Type.STRING)));
-
+      Schema.Field.of("string_field", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("datetime_field", Schema.of(Schema.LogicalType.DATETIME)),
+      Schema.Field.of("decimal_field", Schema.decimalOf(15, 3)));
     /**
      * Create the record as if coming from the reader
      * Date: 2023-06-12, Time: 07:00:00 GMT
@@ -44,6 +47,8 @@ public class StructuredRecordToCSVRecordTransformerTest {
     recordBuilder.set("timestamp_millis_field", 1686553200000L /*2023-06-12T07:00:00Z*/);
     recordBuilder.set("time_millis_field", 1686553200000L /*07:00*/);
     recordBuilder.set("string_field", "testValue");
+    recordBuilder.set("datetime_field", "2023-06-12T07:00:00");
+    recordBuilder.setDecimal("decimal_field", new BigDecimal("1234234.221"));
     StructuredRecord record = recordBuilder.build();
 
     // Converting schema fields to string which can be read by salesforce
@@ -59,6 +64,10 @@ public class StructuredRecordToCSVRecordTransformerTest {
       record.get("time_millis_field"), schema.getField("time_millis_field"));
     String string = StructuredRecordToCSVRecordTransformer.convertSchemaFieldToString(
       record.get("string_field"), schema.getField("string_field"));
+    String datetime = StructuredRecordToCSVRecordTransformer.convertSchemaFieldToString(
+      record.get("datetime_field"), schema.getField("datetime_field"));
+    String decimal = StructuredRecordToCSVRecordTransformer.convertSchemaFieldToString(
+      record.get("decimal_field"), schema.getField("decimal_field"));
 
     Assert.assertEquals(date, "2023-06-12");
     Assert.assertEquals(timestampMicros, "2023-06-12T07:00:00Z");
@@ -66,6 +75,8 @@ public class StructuredRecordToCSVRecordTransformerTest {
     Assert.assertEquals(timestampMillis, "2023-06-12T07:00:00Z");
     Assert.assertEquals(timeMillis, "07:00");
     Assert.assertEquals(string, "testValue");
+    Assert.assertEquals(datetime, "2023-06-12T07:00:00");
+    Assert.assertEquals(decimal, "1234234.221");
 
     /**
      * Create the record as if coming from the reader
@@ -77,6 +88,8 @@ public class StructuredRecordToCSVRecordTransformerTest {
     recordBuilder.set("time_micros_field", -62135593200000000L /*01:00:00.000Z*/);
     recordBuilder.set("timestamp_millis_field", -62135593200000L /*0001-01-01T01:00:00Z*/);
     recordBuilder.set("time_millis_field", -62135593200000L /*01:00*/);
+    recordBuilder.set("datetime_field", "0001-01-01T01:00:00");
+    recordBuilder.setDecimal("decimal_field", new BigDecimal("1.321"));
     StructuredRecord startRecord = recordBuilder.build();
 
     // Converting schema fields to string which can be read by salesforce
@@ -90,11 +103,17 @@ public class StructuredRecordToCSVRecordTransformerTest {
       startRecord.get("timestamp_millis_field"), schema.getField("timestamp_millis_field"));
     String startTimeMillis = StructuredRecordToCSVRecordTransformer.convertSchemaFieldToString(
       startRecord.get("time_millis_field"), schema.getField("time_millis_field"));
+    String dateTimeStart = StructuredRecordToCSVRecordTransformer.convertSchemaFieldToString(
+      startRecord.get("datetime_field"), schema.getField("datetime_field"));
+    String decimalStart = StructuredRecordToCSVRecordTransformer.convertSchemaFieldToString(
+      startRecord.get("decimal_field"), schema.getField("decimal_field"));
 
     Assert.assertEquals(startDate, "0001-01-01");
     Assert.assertEquals(startTimestampMicros, "0001-01-01T01:00:00Z");
     Assert.assertEquals(startTimeMicros, "01:00:00.000Z");
     Assert.assertEquals(startTimestampMillis, "0001-01-01T01:00:00Z");
     Assert.assertEquals(startTimeMillis, "01:00");
+    Assert.assertEquals(dateTimeStart, "0001-01-01T01:00:00");
+    Assert.assertEquals(decimalStart, "1.321");
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.salesforce.InvalidConfigException;
+import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
 import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
@@ -277,7 +278,10 @@ public class SalesforceSourceConfigTest {
                                                                         Mockito.any(), Mockito.any(), Mockito.any(),
                                                                         Mockito.anyString())
       .thenReturn(connectorConfig);
-    SalesforceConnectorInfo salesforceConnectorInfo = new SalesforceConnectorInfo(null, connectorConfig);
+    SalesforceConnectorInfo salesforceConnectorInfo =
+      new SalesforceConnectorInfo(null, connectorConfig,
+                                  SalesforceConstants.isOAuthMacroFunction.apply(
+                                    connectorConfig));
     Mockito.when(mock.getConnection()).thenReturn(salesforceConnectorInfo);
     PowerMockito.when(salesforceConnectorInfo.canAttemptToEstablishConnection()).thenReturn(false);
     ValidationFailure failure;


### PR DESCRIPTION
This PR contains fixes from below PRs.
[PLUGIN-1749] Support added for datetime,decimal logical type in sink plugin
Fix for oAuthInfo issue.
Added code for aborting job in case of failure and logs added

https://github.com/data-integrations/salesforce/pull/238
https://github.com/data-integrations/salesforce/pull/239
https://github.com/data-integrations/salesforce/pull/236

[PLUGIN-1749]: https://cdap.atlassian.net/browse/PLUGIN-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ