### PR TITLE
Add option to allow null values in non-null custom fields in sObjects

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -190,12 +190,24 @@ public class SalesforceBatchSource extends
   }
 
   /**
-   * Get Salesforce schema by query.
+   * Get Salesforce schema by query
    *
    * @param config Salesforce Source Batch config
    * @return schema calculated from query
    */
   public static Schema getSchema(SalesforceSourceConfig config, OAuthInfo oAuthInfo) {
+    return getSchema(config, oAuthInfo, false);
+  }
+
+  /**
+   * Get Salesforce schema by query, with the option to allow null values in non-nullable custom fields
+   *
+   * @param config Salesforce Source Batch config
+   * @param setAllCustomFieldsNullable set all custom fields nullable by default
+   * @return schema calculated from query
+   */
+  public static Schema getSchema(SalesforceSourceConfig config, OAuthInfo oAuthInfo,
+                                 boolean setAllCustomFieldsNullable) {
     String query = config.getQuery(System.currentTimeMillis(), oAuthInfo);
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     try {
@@ -203,7 +215,7 @@ public class SalesforceBatchSource extends
                                                                           config.getConnection().getConnectTimeout(),
                                                                           config.getConnection().getReadTimeout(),
                                                                           config.getConnection().getProxyUrl());
-      return SalesforceSchemaUtil.getSchema(credentials, sObjectDescriptor);
+      return SalesforceSchemaUtil.getSchema(credentials, sObjectDescriptor, setAllCustomFieldsNullable);
     } catch (ConnectionException e) {
       String errorMessage = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       throw new RuntimeException(


### PR DESCRIPTION
## Changes
Since custom sObject fields that are marked as non-nullable can sometimes have null values, a new option is provided to allow these null values by marking the corresponding CDAP schema field as nullable. 