### PR TITLE
Add support for other access token grant types in Authenticator

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/utils/SalesforceClient.java
+++ b/src/e2e-test/java/io/cdap/plugin/utils/SalesforceClient.java
@@ -178,7 +178,7 @@ public class SalesforceClient {
   public static void deletePushTopic(String pushTopicName) {
     try {
       PartnerConnection partnerConnection = new PartnerConnection(
-        Authenticator.createConnectorConfig(new AuthenticatorCredentials(USERNAME, PASSWORD + SECURITYTOKEN,
+        Authenticator.createConnectorConfig(AuthenticatorCredentials.fromParameters(USERNAME, PASSWORD + SECURITYTOKEN,
                                                                          CLIENTID, CLIENTSECRET, PluginPropertyUtils.
                                                                            pluginProp("login.url"),
                                                                          30000, 3600, "")));

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
@@ -64,11 +64,11 @@ public class SalesforceConnectionUtil {
     }
     String proxyUrl = conf.get(SalesforceConstants.CONFIG_PROXY_URL);
     if (oAuthToken != null && instanceURL != null) {
-      return new AuthenticatorCredentials(new OAuthInfo(oAuthToken, instanceURL), connectTimeout, readTimeout,
-                                          proxyUrl);
+      return AuthenticatorCredentials.fromParameters(
+              new OAuthInfo(oAuthToken, instanceURL), connectTimeout, readTimeout, proxyUrl);
     }
 
-    return new AuthenticatorCredentials(conf.get(SalesforceConstants.CONFIG_USERNAME),
+    return AuthenticatorCredentials.fromParameters(conf.get(SalesforceConstants.CONFIG_USERNAME),
                                         conf.get(SalesforceConstants.CONFIG_PASSWORD),
                                         conf.get(SalesforceConstants.CONFIG_CONSUMER_KEY),
                                         conf.get(SalesforceConstants.CONFIG_CONSUMER_SECRET),

--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentials.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentials.java
@@ -20,6 +20,7 @@ import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 
 import java.io.Serializable;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -33,28 +34,18 @@ public class AuthenticatorCredentials implements Serializable {
   private final String consumerKey;
   private final String consumerSecret;
   private final String loginUrl;
+  private final GrantType grantType;
   private final Integer connectTimeout;
   private final Integer readTimeout;
   private final String proxyUrl;
 
-  public AuthenticatorCredentials(OAuthInfo oAuthInfo, Integer connectTimeout, Integer readTimeout, String proxyUrl) {
-    this(Objects.requireNonNull(oAuthInfo), null, null, null, null, null, connectTimeout, readTimeout, proxyUrl);
-  }
-
-  public AuthenticatorCredentials(String username, String password,
-                                  String consumerKey, String consumerSecret, String loginUrl,
-                                  Integer connectTimeout, Integer readTimeout, String proxyUrl) {
-    this(null, Objects.requireNonNull(username), Objects.requireNonNull(password), Objects.requireNonNull(consumerKey),
-         Objects.requireNonNull(consumerSecret), Objects.requireNonNull(loginUrl),
-         Objects.requireNonNull(connectTimeout), Objects.requireNonNull(readTimeout), proxyUrl);
-  }
-
-  private AuthenticatorCredentials(@Nullable OAuthInfo oAuthInfo,
+  public AuthenticatorCredentials(@Nullable OAuthInfo oAuthInfo,
                                    @Nullable String username,
                                    @Nullable String password,
                                    @Nullable String consumerKey,
                                    @Nullable String consumerSecret,
                                    @Nullable String loginUrl,
+                                   @Nullable GrantType grantType,
                                    @Nullable Integer connectTimeout,
                                    @Nullable Integer readTimeout,
                                    @Nullable String proxyUrl) {
@@ -64,6 +55,7 @@ public class AuthenticatorCredentials implements Serializable {
     this.consumerKey = consumerKey;
     this.consumerSecret = consumerSecret;
     this.loginUrl = loginUrl;
+    this.grantType = grantType;
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
     this.proxyUrl = proxyUrl;
@@ -100,6 +92,11 @@ public class AuthenticatorCredentials implements Serializable {
   }
 
   @Nullable
+  public GrantType getGrantType() {
+    return grantType;
+  }
+
+  @Nullable
   public Integer getConnectTimeout() {
     return connectTimeout;
   }
@@ -111,6 +108,62 @@ public class AuthenticatorCredentials implements Serializable {
   @Nullable
   public String getProxyUrl() {
     return proxyUrl;
+  }
+
+  /**
+   * Builder for {@link AuthenticatorCredentials} with credentials for username-password OAuth flow, where
+   * Salesforce OAuth {@link GrantType} is set as "password".
+   */
+  public static Builder getBuilder(String username, String password,
+                                   String consumerKey, String consumerSecret, String loginUrl) {
+    return new Builder(
+            Objects.requireNonNull(username), Objects.requireNonNull(password),
+            Objects.requireNonNull(consumerKey), Objects.requireNonNull(consumerSecret),
+            Objects.requireNonNull(loginUrl)
+    );
+  }
+
+  /**
+   * Builder for {@link AuthenticatorCredentials} with credentials for client-credentials OAuth flow,
+   * where Salesforce OAuth {@link GrantType} is set as "client-credentials".
+   */
+  public static Builder getBuilder(String consumerKey, String consumerSecret, String loginUrl) {
+    return new Builder(
+            Objects.requireNonNull(consumerKey), Objects.requireNonNull(consumerSecret),
+            Objects.requireNonNull(loginUrl)
+    );
+  }
+
+  /**
+   * Builder for {@link AuthenticatorCredentials} with already fetched {@link OAuthInfo}.
+   */
+  public static Builder getBuilder(OAuthInfo oAuthInfo) {
+    return new Builder(Objects.requireNonNull(oAuthInfo));
+  }
+
+  /**
+   * Create an instance of {@link AuthenticatorCredentials} from given set of parameters. Uses "password" grant type
+   * if username and password are non-null. Uses client-credentials grant type otherwise.
+   */
+  public static AuthenticatorCredentials fromParameters(String username, String password,
+                                                        String consumerKey, String consumerSecret, String loginUrl,
+                                                        Integer connectTimeout, Integer readTimeout, String proxyUrl) {
+    AuthenticatorCredentials.Builder builder;
+    if (username != null && password != null) {
+      builder = AuthenticatorCredentials.getBuilder(username, password, consumerKey, consumerSecret, loginUrl);
+    } else {
+      builder = AuthenticatorCredentials.getBuilder(consumerKey, consumerSecret, loginUrl);
+    }
+    return builder.setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).setProxyUrl(proxyUrl).build();
+  }
+
+  /**
+   * Create an instance of {@link AuthenticatorCredentials} from given {@link OAuthInfo} and parameters.
+   */
+  public static AuthenticatorCredentials fromParameters(OAuthInfo oAuthInfo,
+                                                        Integer connectTimeout, Integer readTimeout, String proxyUrl) {
+    return AuthenticatorCredentials.getBuilder(oAuthInfo)
+            .setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).setProxyUrl(proxyUrl).build();
   }
 
   @Override
@@ -131,12 +184,99 @@ public class AuthenticatorCredentials implements Serializable {
       Objects.equals(loginUrl, that.loginUrl) &&
       Objects.equals(connectTimeout, that.connectTimeout) &&
       Objects.equals(readTimeout, that.readTimeout) &&
-      Objects.equals(proxyUrl, that.proxyUrl);
+      Objects.equals(proxyUrl, that.proxyUrl) &&
+      Objects.equals(grantType, that.grantType);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(username, password, consumerKey, consumerSecret, loginUrl, connectTimeout, readTimeout,
-                        proxyUrl);
+                        proxyUrl, grantType);
+  }
+
+  /**
+   * Builder class for creating an instance of {@link AuthenticatorCredentials}.
+   */
+  public static final class Builder {
+    private OAuthInfo oAuthInfo;
+    private String username;
+    private String password;
+    private String consumerKey;
+    private String consumerSecret;
+    private String loginUrl;
+    private GrantType grantType;
+    private Integer connectTimeout;
+    private Integer readTimeout;
+    private String proxyUrl;
+
+    /**
+     * Create an instance of {@link AuthenticatorCredentials} with credentials for username-password OAuth flow, where
+     * Salesforce OAuth {@link GrantType} is set as "password".
+     */
+    public Builder(@Nonnull String username, @Nonnull String password,
+                   @Nonnull String consumerKey, @Nonnull String consumerSecret, @Nonnull String loginUrl) {
+      this.username = username;
+      this.password = password;
+      this.consumerKey = consumerKey;
+      this.consumerSecret = consumerSecret;
+      this.loginUrl = loginUrl;
+      this.grantType = GrantType.PASSWORD;
+    }
+
+    /**
+     * Create an instance of {@link AuthenticatorCredentials} with credentials for client-credentials OAuth flow,
+     * where Salesforce OAuth {@link GrantType} is set as "client-credentials".
+     */
+    public Builder(@Nonnull String consumerKey, @Nonnull String consumerSecret, @Nonnull String loginUrl) {
+      this.consumerKey = consumerKey;
+      this.consumerSecret = consumerSecret;
+      this.loginUrl = loginUrl;
+      this.grantType = GrantType.CLIENT_CREDENTIALS;
+    }
+
+    /**
+     * Create an instance of {@link AuthenticatorCredentials} with already fetched {@link OAuthInfo}.
+     */
+    public Builder(@Nonnull OAuthInfo oAuthInfo) {
+      this.oAuthInfo = oAuthInfo;
+    }
+
+    public Builder setConnectTimeout(Integer connectTimeout) {
+      this.connectTimeout = connectTimeout;
+      return this;
+    }
+
+    public Builder setReadTimeout(Integer readTimeout) {
+      this.readTimeout = readTimeout;
+      return this;
+    }
+
+    public Builder setProxyUrl(String proxyUrl) {
+      this.proxyUrl = proxyUrl;
+      return this;
+    }
+
+    public AuthenticatorCredentials build() {
+      return new AuthenticatorCredentials(oAuthInfo, username, password, consumerKey, consumerSecret,
+              loginUrl, grantType, connectTimeout, readTimeout, proxyUrl);
+    }
+  }
+
+  /**
+   * Represents the grant type parameter for OAuth
+   */
+  public enum GrantType {
+    PASSWORD("password"),
+    CLIENT_CREDENTIALS("client_credentials");
+
+    private final String type;
+
+    GrantType(String type) {
+      this.type = type;
+    }
+
+    public String getType() {
+      return type;
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
@@ -162,11 +162,10 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
     if (oAuthInfo == null) {
       return;
     }
-
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(
+            oAuthInfo, this.getConnectTimeout(), this.getReadTimeoutInMillis(), getProxyUrl());
     try {
-      SalesforceConnectionUtil.getPartnerConnection(new AuthenticatorCredentials(oAuthInfo, this.getConnectTimeout(),
-                                                                                 this.getReadTimeoutInMillis(),
-                                                                                 getProxyUrl()));
+      SalesforceConnectionUtil.getPartnerConnection(credentials);
     } catch (ConnectionException e) {
       String message = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       throw new RuntimeException(

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
@@ -101,10 +101,10 @@ public class SalesforceConnectorInfo {
   public AuthenticatorCredentials getAuthenticatorCredentials() {
     OAuthInfo oAuthInfo = getOAuthInfo();
     if (oAuthInfo != null) {
-      return new AuthenticatorCredentials(oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(),
-                                          config.getProxyUrl());
+      return AuthenticatorCredentials.fromParameters(
+              oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(), config.getProxyUrl());
     }
-    return new AuthenticatorCredentials(config.getUsername(), config.getPassword(), config.getConsumerKey(),
+    return AuthenticatorCredentials.fromParameters(config.getUsername(), config.getPassword(), config.getConsumerKey(),
                                         config.getConsumerSecret(), config.getLoginUrl(), config.getConnectTimeout(),
                                         config.getReadTimeoutInMillis(), config.getProxyUrl());
   }
@@ -140,11 +140,11 @@ public class SalesforceConnectorInfo {
     if (oAuthInfo == null) {
       return;
     }
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(
+            oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(), config.getProxyUrl());
 
     try {
-      SalesforceConnectionUtil.getPartnerConnection(new AuthenticatorCredentials(oAuthInfo, config.getConnectTimeout(),
-                                                                                 config.getReadTimeoutInMillis(),
-                                                                                 config.getProxyUrl()));
+      SalesforceConnectionUtil.getPartnerConnection(credentials);
     } catch (ConnectionException e) {
       String message = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       throw new RuntimeException(

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
@@ -102,7 +102,8 @@ public class SalesforceConnector implements DirectConnector {
    * @throws IOException In case of Salesforce connection failure while browsing
    */
   public BrowseDetail browse(boolean onlyReturnQueryableObjects) throws IOException {
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(config.getUsername(), config.getPassword(),
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(
+                                                                        config.getUsername(), config.getPassword(),
                                                                         config.getConsumerKey(),
                                                                         config.getConsumerSecret(),
                                                                         config.getLoginUrl(),

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
@@ -268,7 +268,7 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
   }
 
   public String getOrgId(OAuthInfo oAuthInfo) throws ConnectionException {
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                         this.getConnection().getConnectTimeout(),
                                                                         this.getConnection().getReadTimeout(),
                                                                         this.connection.getProxyUrl());
@@ -430,7 +430,7 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
   }
 
   private SObjectsDescribeResult getSObjectDescribeResult(FailureCollector collector, OAuthInfo oAuthInfo) {
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                         this.getConnection().getConnectTimeout(),
                                                                         this.getConnection().getReadTimeout(),
                                                                         this.getConnection().getProxyUrl());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -214,7 +214,7 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
   }
 
   public String getOrgId(OAuthInfo oAuthInfo) throws ConnectionException {
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                         this.getConnection().getConnectTimeout(),
                                                                         this.getConnection().getReadTimeout(),
                                                                         this.connection.getProxyUrl());
@@ -277,7 +277,7 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
    */
   protected String getSObjectQuery(String sObjectName, Schema schema, long logicalStartTime, OAuthInfo oAuthInfo) {
     try {
-      AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                           this.getConnection().getConnectTimeout(),
                                                                           this.getConnection().getReadTimeout(),
                                                                           this.connection.getProxyUrl());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -211,7 +211,7 @@ public class SalesforceBatchSource extends
     String query = config.getQuery(System.currentTimeMillis(), oAuthInfo);
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     try {
-      AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                           config.getConnection().getConnectTimeout(),
                                                                           config.getConnection().getReadTimeout(),
                                                                           config.getConnection().getProxyUrl());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
@@ -176,7 +176,7 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
     }
     DescribeGlobalResult describeGlobalResult;
     try {
-      AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                           getConnection().getConnectTimeout(),
                                                                           this.getConnection().getReadTimeout(),
                                                                           this.getConnection().getProxyUrl());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -226,7 +226,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   private void validateCompoundFields(String sObjectName, List<String> fieldNames, FailureCollector collector,
                                       OAuthInfo oAuthInfo) {
     try {
-      AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                           this.getConnection().getConnectTimeout(),
                                                                           this.getConnection().getReadTimeout(),
                                                                           this.getConnection().getProxyUrl());
@@ -332,7 +332,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   }
 
   private boolean isCustomObject(String sObjectName, FailureCollector collector, OAuthInfo oAuthInfo) {
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(oAuthInfo,
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                         this.getConnection().getConnectTimeout(),
                                                                         this.getConnection().getReadTimeout(),
                                                                         this.getConnection().getProxyUrl());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSource.java
@@ -89,7 +89,7 @@ public class SalesforceStreamingSource extends StreamingSource<StructuredRecord>
         && !config.containsMacro(SalesforceStreamingSourceConfig.PROPERTY_PUSH_TOPIC_QUERY)
         && !config.containsMacro(SalesforceStreamingSourceConfig.PROPERTY_SOBJECT_NAME)
         && oAuthInfo != null) {
-        Schema schema = SalesforceSchemaUtil.getSchema(new AuthenticatorCredentials(oAuthInfo,
+        Schema schema = SalesforceSchemaUtil.getSchema(AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                                     config.getConnection()
                                                                                       .getConnectTimeout(),
                                                                                     config.getConnection()

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -233,7 +233,7 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
 
     try {
       PartnerConnection partnerConnection = new PartnerConnection(
-        Authenticator.createConnectorConfig(new AuthenticatorCredentials(oAuthInfo,
+        Authenticator.createConnectorConfig(AuthenticatorCredentials.fromParameters(oAuthInfo,
                                                                          this.getConnection().getConnectTimeout(),
                                                                          this.getConnection().getReadTimeout(),
                                                                          this.connection.getProxyUrl())));

--- a/src/test/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentialsTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentialsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.salesforce.authenticator;
+
+import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AuthenticatorCredentialsTest {
+    private static final String USERNAME = "dummy_user";
+    private static final String PASSWORD = "dummy_pass";
+    private static final String CONSUMER_KEY = "key123";
+    private static final String CONSUMER_SECRET = "secret123";
+    private static final String LOGIN_URL = "login-url";
+    private static final OAuthInfo O_AUTH_INFO = new OAuthInfo("dummyAccessToken", "dummyUrl");
+
+    @Test
+    public void buildFromParameters_passwordFlow() {
+        AuthenticatorCredentials expected = AuthenticatorCredentials.getBuilder(
+                USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL).build();
+
+        AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(
+                USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL, null, null, null);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void buildFromParameters_clientCredentialsFlow() {
+        AuthenticatorCredentials expected = AuthenticatorCredentials.getBuilder(
+                CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL).build();
+
+        AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(
+                null, null, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL, null, null, null);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void buildFromParameters_OAuthFlow() {
+        AuthenticatorCredentials expected = AuthenticatorCredentials.getBuilder(O_AUTH_INFO).build();
+
+        AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(O_AUTH_INFO, null, null, null);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceETLTest.java
@@ -92,7 +92,7 @@ public abstract class BaseSalesforceETLTest extends HydratorTestBase {
     }
     Integer connectTimeout = Integer.parseInt(CONNECT_TIMEOUT);
     Integer readTimeout = Integer.parseInt(READ_TIMEOUT);
-    AuthenticatorCredentials credentials = new AuthenticatorCredentials(USERNAME, PASSWORD, CONSUMER_KEY,
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(USERNAME, PASSWORD, CONSUMER_KEY,
                                                                         CONSUMER_SECRET, LOGIN_URL, connectTimeout,
                                                                         readTimeout, null);
     partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);


### PR DESCRIPTION
## Changes
- Added a new "GrantType" enum and parameter to AuthenticatorCredentials
- Refactored AuthenticatorCredentials to infer the correct grant_type from a provided set of parameters
- Changed Authenticator to use the correct OAuth flow based on what grant_type is passed via AuthenticatorCredentials