### PR TITLE
Added hook for treating all fields as nullable

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -203,11 +203,11 @@ public class SalesforceBatchSource extends
    * Get Salesforce schema by query, with the option to allow null values in non-nullable custom fields
    *
    * @param config Salesforce Source Batch config
-   * @param setAllCustomFieldsNullable set all custom fields nullable by default
+   * @param setAllFieldsNullable set all custom fields nullable by default
    * @return schema calculated from query
    */
   public static Schema getSchema(SalesforceSourceConfig config, OAuthInfo oAuthInfo,
-                                 boolean setAllCustomFieldsNullable) {
+                                 boolean setAllFieldsNullable) {
     String query = config.getQuery(System.currentTimeMillis(), oAuthInfo);
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     try {
@@ -215,7 +215,7 @@ public class SalesforceBatchSource extends
                                                                           config.getConnection().getConnectTimeout(),
                                                                           config.getConnection().getReadTimeout(),
                                                                           config.getConnection().getProxyUrl());
-      return SalesforceSchemaUtil.getSchema(credentials, sObjectDescriptor, setAllCustomFieldsNullable);
+      return SalesforceSchemaUtil.getSchema(credentials, sObjectDescriptor, setAllFieldsNullable);
     } catch (ConnectionException e) {
       String errorMessage = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       throw new RuntimeException(

--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceSchemaUtilTest.java
@@ -169,11 +169,11 @@ public class SalesforceSchemaUtilTest {
   }
 
   @Test
-  public void  testSchemaWithSetAllCustomFieldsNullable() {
+  public void testSchemaWithSetAllFieldsNullable() {
     String objectName = "CustomTable";
 
     List<SObjectDescriptor.FieldDescriptor> fieldDescriptors = Stream
-            .of("Name", "Value", "CreatedDate")
+            .of("Name", "Value", "CreatedDate", "UpdatedDate")
             .map(name -> getFieldWithType(name, FieldType.anyType, false))
             .map(SObjectDescriptor.FieldDescriptor::new)
             .collect(Collectors.toList());
@@ -183,19 +183,23 @@ public class SalesforceSchemaUtilTest {
             Collections.singletonList("Value"), null, SalesforceFunctionType.NONE));
     fieldDescriptors.add(new SObjectDescriptor.FieldDescriptor(
             Collections.singletonList("CreatedDate"), null, SalesforceFunctionType.NONE));
+    fieldDescriptors.add(new SObjectDescriptor.FieldDescriptor(
+        Collections.singletonList("UpdatedDate"), null, SalesforceFunctionType.NONE));
     SObjectDescriptor sObjectDescriptor = new SObjectDescriptor(objectName, fieldDescriptors, ImmutableList.of());
 
     Map<String, Field> objectFields = new LinkedHashMap<>();
     objectFields.put("Name", getCustomFieldWithType("Name", FieldType.string, false));
     objectFields.put("Value", getCustomFieldWithType("Value", FieldType.currency, false));
     objectFields.put("CreatedDate", getCustomFieldWithType("CreatedDate", FieldType.date, false));
+    objectFields.put("UpdatedDate", getCustomFieldWithType("UpdatedDate", FieldType.date, false));
     SObjectsDescribeResult describeResult = SObjectsDescribeResult.of(ImmutableMap.of(objectName, objectFields));
 
     // Testing case with flag setAllCustomFieldsNullable = true
     Schema expectedSchema = Schema.recordOf("output",
             Schema.Field.of("Name", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
             Schema.Field.of("Value", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
-            Schema.Field.of("CreatedDate", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE)))
+            Schema.Field.of("CreatedDate", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
+            Schema.Field.of("UpdatedDate", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE)))
     );
 
     Schema actualSchema = SalesforceSchemaUtil.getSchemaWithFields(sObjectDescriptor, describeResult, true);
@@ -206,7 +210,8 @@ public class SalesforceSchemaUtilTest {
     expectedSchema = Schema.recordOf("output",
             Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
             Schema.Field.of("Value", Schema.of(Schema.Type.DOUBLE)),
-            Schema.Field.of("CreatedDate", Schema.of(Schema.LogicalType.DATE))
+            Schema.Field.of("CreatedDate", Schema.of(Schema.LogicalType.DATE)),
+            Schema.Field.of("UpdatedDate", Schema.of(Schema.LogicalType.DATE))
     );
 
     actualSchema = SalesforceSchemaUtil.getSchemaWithFields(sObjectDescriptor, describeResult, false);


### PR DESCRIPTION
Changing the code to make sure that all the fields are converted to Nullable based on the hook. In the previous implementation this was only added for Custom objects.