### PR TITLE
[PLUGIN-1892] Add BulkConnectionRetryWrapper to make retry calls to salesforce api failures

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceBulkUtil.java
@@ -32,6 +32,7 @@ import com.sforce.soap.partner.SessionHeader_element;
 import com.sforce.ws.ConnectionException;
 import com.sforce.ws.ConnectorConfig;
 import com.sforce.ws.SessionRenewer;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
@@ -65,8 +66,8 @@ public final class SalesforceBulkUtil {
    * @throws AsyncApiException if there is an issue creating the job
    */
 
-  public static JobInfo createJob(BulkConnection bulkConnection, String sObject, OperationEnum operationEnum,
-                                  @Nullable String externalIdField,
+  public static JobInfo createJob(BulkConnectionRetryWrapper bulkConnection, String sObject,
+                                  OperationEnum operationEnum, @Nullable String externalIdField,
                                   ConcurrencyMode concurrencyMode, ContentType contentType) throws AsyncApiException {
     JobInfo job = new JobInfo();
     job.setObject(sObject);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
@@ -41,6 +41,7 @@ import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorBaseConfig;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
 import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,6 +152,26 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
   @Macro
   @Description("Whether to validate the field data types of the input schema as per Salesforce specific data types")
   private final Boolean datatypeValidation;
+
+  @Name(SalesforceSourceConstants.PROPERTY_INITIAL_RETRY_DURATION)
+  @Description("Time taken for the first retry. Default is 5 seconds.")
+  @Nullable
+  private Long initialRetryDuration;
+
+  @Name(SalesforceSourceConstants.PROPERTY_MAX_RETRY_DURATION)
+  @Description("Maximum time in seconds retries can take. Default is 80 seconds.")
+  @Nullable
+  private Long maxRetryDuration;
+
+  @Name(SalesforceSourceConstants.PROPERTY_MAX_RETRY_COUNT)
+  @Description("Maximum number of retries allowed. Default is 5.")
+  @Nullable
+  private Integer maxRetryCount;
+
+  @Name(SalesforceSourceConstants.PROPERTY_RETRY_REQUIRED)
+  @Description("Retry is required or not for some of the internal call failures.")
+  @Nullable
+  private Boolean retryOnBackendError;
 
   public SalesforceSinkConfig(String referenceName,
                               @Nullable String clientId,
@@ -275,6 +296,23 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
     PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection
       (credentials);
     return partnerConnection.getUserInfo().getOrganizationId();
+  }
+
+  public boolean isRetryRequired() {
+    return retryOnBackendError == null || retryOnBackendError;
+  }
+
+  public long getInitialRetryDuration() {
+    return initialRetryDuration == null ? SalesforceSourceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS :
+        initialRetryDuration;
+  }
+
+  public long getMaxRetryDuration() {
+    return maxRetryDuration == null ? SalesforceSourceConstants.DEFULT_MAX_RETRY_DURATION_SECONDS : maxRetryDuration;
+  }
+
+  public int getMaxRetryCount() {
+    return maxRetryCount == null ? SalesforceSourceConstants.DEFAULT_MAX_RETRY_COUNT : maxRetryCount;
   }
 
   public void validate(Schema schema, FailureCollector collector, @Nullable OAuthInfo oAuthInfo) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -45,6 +45,7 @@ import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
 
@@ -164,7 +165,10 @@ public class SalesforceBatchSource extends
       bulkConnection.addHeader(SalesforceSourceConstants.HEADER_ENABLE_PK_CHUNK,
           String.join(";", chunkHeaderValues));
     }
-    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnection,
+    BulkConnectionRetryWrapper bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection,
+      config.isRetryRequired(), config.getInitialRetryDuration(), config.getMaxRetryDuration(),
+      config.getMaxRetryCount());
+    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnectionRetryWrapper,
         enablePKChunk, config.getOperation(), config.getInitialRetryDuration(), config.getMaxRetryDuration(),
           config.getMaxRetryCount(), config.isRetryRequired());
     return querySplits;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
@@ -28,9 +28,9 @@ import dev.failsafe.TimeoutExceededException;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.salesforce.BulkAPIBatchException;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
-import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
@@ -78,13 +78,15 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
   private String batchId;
   private String[] resultIds;
   private int resultIdIndex;
+  private BulkConnectionRetryWrapper bulkConnectionRetryWrapper;
 
   public SalesforceBulkRecordReader(Schema schema) {
-    this(schema, null, null, null);
+    this(schema, null, null, null, null);
   }
 
   @VisibleForTesting
-  SalesforceBulkRecordReader(Schema schema, String jobId, String batchId, String[] resultIds) {
+  SalesforceBulkRecordReader(Schema schema, String jobId, String batchId, String[] resultIds,
+      BulkConnection bulkConnection) {
     this.schema = schema;
     this.resultIdIndex = 0;
     this.jobId = jobId;
@@ -94,6 +96,8 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     maxRetryDuration = SalesforceSourceConstants.DEFULT_MAX_RETRY_DURATION_SECONDS;
     maxRetryCount = SalesforceSourceConstants.DEFAULT_MAX_RETRY_COUNT;
     isRetryRequired = true;
+    bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection, isRetryRequired, initialRetryDuration,
+        maxRetryDuration, maxRetryCount);
   }
 
   /**
@@ -128,6 +132,8 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
 
     try {
       bulkConnection = new BulkConnection(Authenticator.createConnectorConfig(credentials));
+      bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection, isRetryRequired, initialRetryDuration,
+        maxRetryDuration, maxRetryCount);
       resultIds = waitForBatchResults(bulkConnection);
       LOG.debug("Batch {} returned {} results", batchId, resultIds.length);
       setupParser();
@@ -205,15 +211,8 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
         resultIdIndex, resultIds.length));
     }
     try {
-      final InputStream queryResponseStream;
-      if (isRetryRequired) {
-        queryResponseStream =
-          Failsafe.with(SalesforceSplitUtil.getRetryPolicy(initialRetryDuration, maxRetryDuration, maxRetryCount))
-            .get(() -> getQueryResultStream(bulkConnection));
-      } else {
-        queryResponseStream = bulkConnection.getQueryResultStream(jobId, batchId, resultIds[resultIdIndex]);
-      }
-
+      final InputStream queryResponseStream = bulkConnectionRetryWrapper
+          .getQueryResultStream(jobId, batchId, resultIds[resultIdIndex]);
         CSVFormat csvFormat = CSVFormat.DEFAULT
           .withHeader()
           .withQuoteMode(QuoteMode.ALL)

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce.plugin.source.batch.util;
+
+import com.sforce.async.AsyncApiException;
+import com.sforce.async.BatchInfo;
+import com.sforce.async.BatchInfoList;
+import com.sforce.async.BulkConnection;
+import com.sforce.async.JobInfo;
+import com.sforce.ws.ConnectorConfig;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBulkRecordReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * BulkConnectionRetryWrapper class to retry all the salesforce api calls in case of failure.
+ */
+public class BulkConnectionRetryWrapper {
+
+  private final BulkConnection bulkConnection;
+  private final RetryPolicy retryPolicy;
+  private static final Logger LOG = LoggerFactory.getLogger(BulkConnectionRetryWrapper.class);
+  private final boolean retryOnBackendError;
+  private final long maxRetryDuration;
+  private final int maxRetryCount;
+  private final long initialRetryDuration;
+
+  public BulkConnectionRetryWrapper(BulkConnection bulkConnection, boolean isRetryRequired,
+                                    long initialRetryDuration, long maxRetryDuration, int maxRetryCount) {
+    this.bulkConnection = bulkConnection;
+    this.retryOnBackendError = isRetryRequired;
+    this.initialRetryDuration = initialRetryDuration;
+    this.maxRetryDuration = maxRetryDuration;
+    this.maxRetryCount = maxRetryCount;
+    this.retryPolicy = SalesforceSplitUtil.getRetryPolicy(initialRetryDuration, maxRetryDuration, maxRetryCount);
+  }
+
+  public JobInfo createJob(JobInfo jobInfo) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      return bulkConnection.createJob(jobInfo);
+    }
+    Object resultJobInfo = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while creating job."))
+        .get(() -> {
+          try {
+            return bulkConnection.createJob(jobInfo);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (JobInfo) resultJobInfo;
+  }
+
+  public JobInfo getJobStatus(String jobId) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      return bulkConnection.getJobStatus(jobId);
+    }
+    Object resultJobInfo = Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while getting job status."))
+        .get(() -> {
+          try {
+            return bulkConnection.getJobStatus(jobId);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (JobInfo) resultJobInfo;
+  }
+
+  public void updateJob(JobInfo jobInfo) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      bulkConnection.updateJob(jobInfo);
+      return;
+    }
+    Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while updating job."))
+        .get(() -> {
+          try {
+            return bulkConnection.updateJob(jobInfo);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+  }
+
+  public BatchInfoList getBatchInfoList(String jobId) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      return bulkConnection.getBatchInfoList(jobId);
+    }
+    Object batchInfoList = Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while getting batch info list."))
+        .get(() -> {
+          try {
+            return bulkConnection.getBatchInfoList(jobId);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (BatchInfoList) batchInfoList;
+  }
+
+  public BatchInfo getBatchInfo(String jobId, String batchId) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      return bulkConnection.getBatchInfo(jobId, batchId);
+    }
+    Object batchInfo = Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while getting batch status."))
+        .get(() -> {
+          try {
+            return bulkConnection.getBatchInfo(jobId, batchId);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (BatchInfo) batchInfo;
+  }
+
+  public InputStream getBatchResultStream(String jobId, String batchId) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      return bulkConnection.getBatchResultStream(jobId, batchId);
+    }
+    Object inputStream = Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while getting batch result stream."))
+        .get(() -> {
+          try {
+            return bulkConnection.getBatchResultStream(jobId, batchId);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (InputStream) inputStream;
+  }
+
+  public InputStream getQueryResultStream(String jobId, String batchId, String resultId) throws AsyncApiException {
+    if (!retryOnBackendError) {
+      return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
+    }
+    Object inputStream = Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while getting query result stream."))
+        .get(() -> {
+          try {
+            return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (InputStream) inputStream;
+  }
+
+  public BatchInfo createBatchFromStream(String query, JobInfo job) throws AsyncApiException,
+    SalesforceQueryExecutionException, IOException {
+    if (!retryOnBackendError) {
+      return createBatchFromStreamI(query, job);
+    }
+    Object batchInfo = Failsafe.with(retryPolicy)
+        .onFailure(event -> LOG.info("Failed while creating batch from stream."))
+        .get(() -> {
+          try {
+            return createBatchFromStreamI(query, job);
+          } catch (AsyncApiException e) {
+            throw new SalesforceQueryExecutionException(e.getMessage());
+          }
+        });
+    return (BatchInfo) batchInfo;
+  }
+
+  private BatchInfo createBatchFromStreamI(String query, JobInfo job) throws
+    SalesforceQueryExecutionException, IOException, AsyncApiException {
+    BatchInfo batchInfo = null;
+    try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
+      batchInfo = bulkConnection.createBatchFromStream(job, bout);
+    } catch (AsyncApiException exception) {
+      LOG.warn("The bulk query job {} failed. Job State: {}.", job.getId(), job.getState());
+      if (SalesforceBulkRecordReader.RETRY_ON_REASON.contains(exception.getExceptionCode())) {
+        throw new SalesforceQueryExecutionException(exception);
+      }
+      throw exception;
+    }
+    return batchInfo;
+  }
+
+  public ConnectorConfig getConfig() {
+    return bulkConnection.getConfig();
+  }
+  
+  public BulkConnection getBukConnection() {
+    return bulkConnection;
+  }
+}

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
@@ -65,7 +65,7 @@ public final class SalesforceSplitUtil {
    * @param enablePKChunk  indicates if pk chunking is enabled
    * @return list of salesforce splits
    */
-  public static List<SalesforceSplit> getQuerySplits(String query, BulkConnection bulkConnection,
+  public static List<SalesforceSplit> getQuerySplits(String query, BulkConnectionRetryWrapper bulkConnection,
                                                      boolean enablePKChunk, String operation,
                                                      Long initialRetryDuration, Long maxRetryDuration,
                                                      Integer maxRetryCount, Boolean retryOnBackendError) {
@@ -85,7 +85,7 @@ public final class SalesforceSplitUtil {
    * @param enablePKChunk  enable PK Chunking
    * @return array of batch info
    */
-  private static BatchInfo[] getBatches(String query, BulkConnection bulkConnection,
+  private static BatchInfo[] getBatches(String query, BulkConnectionRetryWrapper bulkConnection,
                                         boolean enablePKChunk, String operation,
                                         Long initialRetryDuration, Long maxRetryDuration,
                                         Integer maxRetryCount, Boolean retryOnBackendError) {
@@ -114,7 +114,7 @@ public final class SalesforceSplitUtil {
    * @throws AsyncApiException if there is an issue creating the job
    * @throws IOException       failed to close the query
    */
-  private static BatchInfo[] runBulkQuery(BulkConnection bulkConnection, String query,
+  private static BatchInfo[] runBulkQuery(BulkConnectionRetryWrapper bulkConnection, String query,
                                           boolean enablePKChunk, String operation,
                                           Long initialRetryDuration, Long maxRetryDuration,
                                           Integer maxRetryCount, Boolean retryOnBackendError)
@@ -123,17 +123,9 @@ public final class SalesforceSplitUtil {
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectDescriptor.getName(), getOperationEnum(operation),
       null, ConcurrencyMode.Parallel, ContentType.CSV);
-    final BatchInfo batchInfo;
+    BatchInfo batchInfo;
     try {
-      if (retryOnBackendError) {
-        batchInfo =
-          Failsafe.with(getRetryPolicy(initialRetryDuration, maxRetryDuration, maxRetryCount))
-            .get(() -> createBatchFromStream(bulkConnection, query, job));
-      } else {
-        try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
-          batchInfo = bulkConnection.createBatchFromStream(job, bout);
-        }
-      }
+      batchInfo = bulkConnection.createBatchFromStream(query, job);
       if (enablePKChunk) {
         LOG.debug("PKChunking is enabled");
         return waitForBatchChunks(bulkConnection, job.getId(), batchInfo.getId());
@@ -155,23 +147,11 @@ public final class SalesforceSplitUtil {
         throw (AsyncApiException) e.getCause();
       }
       throw e;
+    } catch (SalesforceQueryExecutionException e) {
+      throw new RuntimeException(e);
     }
   }
 
-  private static BatchInfo createBatchFromStream(BulkConnection bulkConnection, String query, JobInfo job) throws
-    SalesforceQueryExecutionException, IOException, AsyncApiException {
-    BatchInfo batchInfo = null;
-    try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
-      batchInfo = bulkConnection.createBatchFromStream(job, bout);
-    } catch (AsyncApiException exception) {
-      LOG.warn("The bulk query job {} failed. Job State: {}", job.getId(), job.getState());
-      if (SalesforceBulkRecordReader.RETRY_ON_REASON.contains(exception.getExceptionCode())) {
-        throw new SalesforceQueryExecutionException(exception);
-      }
-      throw exception;
-    }
-    return batchInfo;
-  }
 
   /**
    * Initializes bulk connection based on given Hadoop credentials configuration.
@@ -198,7 +178,8 @@ public final class SalesforceSplitUtil {
    * @return Array with Batches created by Salesforce API
    * @throws AsyncApiException if there is an issue creating the job
    */
-  private static BatchInfo[] waitForBatchChunks(BulkConnection bulkConnection, String jobId, String initialBatchId)
+  private static BatchInfo[] waitForBatchChunks(BulkConnectionRetryWrapper bulkConnection,
+                                                String jobId, String initialBatchId)
     throws AsyncApiException {
     BatchInfo initialBatchInfo = null;
     for (int i = 0; i < SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES; i++) {
@@ -269,8 +250,11 @@ public final class SalesforceSplitUtil {
       .handle(SalesforceQueryExecutionException.class)
       .withBackoff(Duration.ofSeconds(initialRetryDuration), Duration.ofSeconds(maxRetryDuration), 2)
       .withMaxRetries(maxRetryCount)
-      .onRetry(event -> LOG.debug("Retrying Salesforce Bulk Query. Retry count: {}", event
-        .getAttemptCount()))
+      .onRetry(event -> {
+        Throwable t = event.getLastException();
+        LOG.warn("Attempt #{} failed while executing job with error: {}", event.getAttemptCount(), t.getMessage(), t);
+        LOG.debug("Retrying Salesforce Bulk Query. Retry count: {}", event.getAttemptCount());
+      })
       .onSuccess(event -> LOG.debug("Salesforce Bulk Query executed successfully."))
       .onRetriesExceeded(event -> LOG.error("Retry limit reached for Salesforce Bulk Query."))
       .build();

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
@@ -292,8 +292,8 @@ public class SalesforceBulkRecordReaderTest {
       resultIds[i] = String.format("result%d", i);
     }
 
-    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds);
     BulkConnection mock = Mockito.mock(BulkConnection.class);
+    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds, mock);
     FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("bulkConnection"), mock);
     for (int i = 0; i < csvStrings.length; i++) {
       Mockito.when(mock.getQueryResultStream(jobId, batchId, resultIds[i]))
@@ -354,8 +354,8 @@ public class SalesforceBulkRecordReaderTest {
       resultIds[i] = String.format("result%d", i);
     }
 
-    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds);
     BulkConnection mock = Mockito.mock(BulkConnection.class);
+    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds, mock);
     FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("bulkConnection"), mock);
     for (int i = 0; i < csvStrings.length; i++) {
       AsyncApiException salesforceQueryExecutionException =
@@ -370,7 +370,7 @@ public class SalesforceBulkRecordReaderTest {
     reader.setupParser();
   }
 
-  @Test (expected = AsyncApiException.class)
+  @Test (expected = FailsafeException.class)
   public void testSetupParserWithoutRetry() throws Exception {
     String csvString1 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
       "\"0061i000003XNcBAAW\",\"false\",\"1500.0\",\"2019-02-22T07:03:21.000Z\",\"2019-01-01\",\"12:00:30.000Z\"\n";
@@ -398,8 +398,8 @@ public class SalesforceBulkRecordReaderTest {
       resultIds[i] = String.format("result%d", i);
     }
 
-    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds);
     BulkConnection mock = Mockito.mock(BulkConnection.class);
+    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds, mock);
     FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("bulkConnection"), mock);
     for (int i = 0; i < csvStrings.length; i++) {
         AsyncApiException salesforceQueryExecutionException =
@@ -480,8 +480,9 @@ public class SalesforceBulkRecordReaderTest {
       resultIds[i] = String.format("result%d", i);
     }
 
-    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, new String[]{resultId});
     BulkConnection mockConnection = Mockito.mock(BulkConnection.class);
+    SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, new String[]{resultId},
+        mockConnection);
     AsyncApiException salesforceQueryExecutionException =
       Mockito.mock(AsyncApiException.class);
     Mockito.when(mockConnection.getQueryResultStream(jobId, batchId, resultId))

--- a/widgets/Salesforce-batchsink.json
+++ b/widgets/Salesforce-batchsink.json
@@ -218,6 +218,49 @@
             },
             "default": "true"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Initial Retry Duration",
+          "name": "initialRetryDuration",
+          "widget-attributes": {
+            "min": "1",
+            "default": "5"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Duration",
+          "name": "maxRetryDuration",
+          "widget-attributes": {
+            "min": "6",
+            "default": "80"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Count",
+          "name": "maxRetryCount",
+          "widget-attributes": {
+            "min": "1",
+            "default": "5"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Retry On Backend Error",
+          "name": "retryOnBackendError",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "true"
+          }
         }
       ]
     }


### PR DESCRIPTION
## [PLUGIN-1892] Add BulkConnectionRetryWrapper to make retry calls to salesforce api failures

Jira : [PLUGIN-1892](https://cdap.atlassian.net/browse/PLUGIN-1892)

### Description

Default Description

### UI Field

- Modified `Salesforce-batchsink.json`

### Docs

- No Changes made to docs.

### Code change

- Added `BulkConnectionRetryWrapper.java`
- Modified `SalesforceBulkUtil.java`
- Modified `SalesforceOutputFormatProvider.java`
- Modified `SalesforceSinkConfig.java`
- Modified `SalesforceBatchMultiSource.java`
- Modified `SalesforceBatchSource.java`
- Modified `SalesforceBulkRecordReader.java`
- Modified `SalesforceSplitUtil.java`

### Unit Tests

- Modified `SalesforceBulkRecordReaderTest.java`



[PLUGIN-1892]: https://cdap.atlassian.net/browse/PLUGIN-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUGIN-1892]: https://cdap.atlassian.net/browse/PLUGIN-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ