### PR TITLE
Refactor SalesforceQueryExecutionException handling to include the full exception object

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
@@ -64,7 +64,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.createJob(jobInfo);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (JobInfo) resultJobInfo;
@@ -80,7 +80,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.getJobStatus(jobId);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (JobInfo) resultJobInfo;
@@ -97,7 +97,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.updateJob(jobInfo);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
   }
@@ -112,7 +112,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.getBatchInfoList(jobId);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (BatchInfoList) batchInfoList;
@@ -128,7 +128,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.getBatchInfo(jobId, batchId);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (BatchInfo) batchInfo;
@@ -144,7 +144,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.getBatchResultStream(jobId, batchId);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (InputStream) inputStream;
@@ -160,7 +160,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (InputStream) inputStream;
@@ -177,7 +177,7 @@ public class BulkConnectionRetryWrapper {
           try {
             return createBatchFromStreamI(query, job);
           } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e.getMessage());
+            throw new SalesforceQueryExecutionException(e);
           }
         });
     return (BatchInfo) batchInfo;


### PR DESCRIPTION
Refactor SalesforceQueryExecutionException handling to include the full exception object

## Test
![image](https://github.com/user-attachments/assets/2fdc175d-1f2b-462f-b027-c3810709c05d)
![image](https://github.com/user-attachments/assets/d2c8023c-7890-4515-828a-5fcf871b2254)

```log
2025-06-05 13:15:19,959 - DEBUG [SparkRunner-phase-1:i.c.p.s.p.s.b.u.SalesforceSplitUtil@256] - Retrying Salesforce Bulk Query. Retry count: 5
2025-06-05 13:15:19,967 - ERROR [SparkRunner-phase-1:i.c.p.s.p.s.b.u.SalesforceSplitUtil@259] - Retry limit reached for Salesforce Bulk Query.
2025-06-05 13:15:19,970 - INFO  [SparkRunner-phase-1:i.c.p.s.p.s.b.u.BulkConnectionRetryWrapper@63] - Failed while creating job.
2025-06-05 13:15:20,516 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@98] - Spark Program 'phase-1' failed.
org.apache.tephra.TransactionFailureException: Exception raised from TxRunnable.run() io.cdap.cdap.internal.app.runtime.AbstractContext$$Lambda$678/370932406@6cd12357
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.finishExecute(Transactions.java:236)
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.execute(Transactions.java:221)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:554)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:540)
	at io.cdap.cdap.app.runtime.spark.BasicSparkClientContext.execute(BasicSparkClientContext.java:357)
	at io.cdap.cdap.etl.common.submit.SubmitterPlugin.prepareRun(SubmitterPlugin.java:72)
	at io.cdap.cdap.etl.common.submit.PipelinePhasePreparer.prepare(PipelinePhasePreparer.java:158)
	at io.cdap.cdap.etl.spark.AbstractSparkPreparer.prepare(AbstractSparkPreparer.java:87)
	at io.cdap.cdap.etl.spark.batch.SparkPreparer.prepare(SparkPreparer.java:94)
	at io.cdap.cdap.etl.spark.batch.ETLSpark.initialize(ETLSpark.java:131)
	at io.cdap.cdap.api.spark.AbstractSpark.initialize(AbstractSpark.java:131)
	at io.cdap.cdap.api.spark.AbstractSpark.initialize(AbstractSpark.java:33)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService$1.initialize(SparkRuntimeService.java:192)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService$1.initialize(SparkRuntimeService.java:187)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$initializeProgram$8(AbstractContext.java:650)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.initializeProgram(AbstractContext.java:647)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.initialize(SparkRuntimeService.java:550)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.startUp(SparkRuntimeService.java:234)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'Salesforce' encountered : dev.failsafe.FailsafeException: io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException: [AsyncApiException  exceptionCode='ClientInputError'
 exceptionMessage='Failed to create job '
]

	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.prepareRun(WrappedBatchSource.java:52)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.prepareRun(WrappedBatchSource.java:35)
	at io.cdap.cdap.etl.common.submit.SubmitterPlugin.lambda$prepareRun$2(SubmitterPlugin.java:74)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$execute$5(AbstractContext.java:558)
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.finishExecute(Transactions.java:234)
	... 21 common frames omitted
Caused by: dev.failsafe.FailsafeException: io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException: [AsyncApiException  exceptionCode='ClientInputError'
 exceptionMessage='Failed to create job '
]

	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:196)
	at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
	at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:112)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.createJob(BulkConnectionRetryWrapper.java:64)
	at io.cdap.plugin.salesforce.SalesforceBulkUtil.createJob(SalesforceBulkUtil.java:81)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.runBulkQuery(SalesforceSplitUtil.java:124)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.getBatches(SalesforceSplitUtil.java:97)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.getQuerySplits(SalesforceSplitUtil.java:72)
	at io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource.getSplits(SalesforceBatchSource.java:171)
	at io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource.prepareRun(SalesforceBatchSource.java:142)
	at io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource.prepareRun(SalesforceBatchSource.java:63)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.lambda$prepareRun$0(WrappedBatchSource.java:53)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 26 common frames omitted
Caused by: io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException: [AsyncApiException  exceptionCode='ClientInputError'
 exceptionMessage='Failed to create job '
]

	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.lambda$createJob$1(BulkConnectionRetryWrapper.java:73)
	at dev.failsafe.Functions.lambda$toCtxSupplier$11(Functions.java:243)
	at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
	at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
	... 39 common frames omitted
Caused by: com.sforce.async.AsyncApiException: ClientInputError : Failed to create job 
	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.lambda$createJob$1(BulkConnectionRetryWrapper.java:69)
	... 43 common frames omitted
Caused by: java.io.IOException: Simulated IOException for testing retry logic
	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.lambda$createJob$1(BulkConnectionRetryWrapper.java:67)
	... 43 common frames omitted
```