### PR TITLE
Wide Record reader fix.

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -47,7 +47,7 @@ public class SalesforceConstants {
   public static final int RANGE_FILTER_MIN_VALUE = 0;
   public static final int SOQL_MAX_LENGTH = 20000;
 
-  public static final int DEFAULT_CONNECTION_TIMEOUT_MS = 30000;
+  public static final int DEFAULT_CONNECTION_TIMEOUT_MS = 120_000;
   public static final int DEFAULT_READ_TIMEOUT_SEC = 18000;
   public static final String PROPERTY_CONNECT_TIMEOUT = "connectTimeout";
   public static final String PROPERTY_READ_TIMEOUT = "readTimeout";

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReader.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,10 +49,17 @@ public class SalesforceWideRecordReader extends SalesforceBulkRecordReader {
 
   private final String query;
   private final SoapRecordToMapTransformer transformer;
+  private Iterator<List<Map<String, ?>>> batchIterator;
 
   private List<Map<String, ?>> results;
   private Map<String, ?> value;
   private int index;
+  private AuthenticatorCredentials credentials;
+  private PartnerConnection partnerConnection;
+  private SObjectDescriptor sObjectDescriptor;
+  private List<String> fieldsNames;
+  private String fields;
+  private String sObjectName;
 
   public SalesforceWideRecordReader(Schema schema, String query, SoapRecordToMapTransformer transformer) {
     super(schema);
@@ -63,7 +71,7 @@ public class SalesforceWideRecordReader extends SalesforceBulkRecordReader {
   public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext) throws IOException,
     InterruptedException {
     Configuration conf = taskAttemptContext.getConfiguration();
-    AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
+    credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
     initialize(inputSplit, credentials);
   }
 
@@ -73,33 +81,21 @@ public class SalesforceWideRecordReader extends SalesforceBulkRecordReader {
     // Use default configurations of BulkRecordReader.
     super.initialize(inputSplit, credentials);
 
+    this.credentials = credentials;
+
     List<Map<String, ?>> fetchedIdList = fetchBulkQueryIds();
     LOG.debug("Number of records received from batch job for wide object: '{}'", fetchedIdList.size());
 
+    List<List<Map<String, ?>>> partitions =
+      Lists.partition(fetchedIdList, SalesforceSourceConstants.WIDE_QUERY_MAX_BATCH_COUNT);
+    LOG.debug("Number of partitions to be fetched for wide object: '{}'", partitions.size());
     try {
-      PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
-      SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
-      List<String> fieldsNames = sObjectDescriptor.getFieldsNames();
-      String fields = String.join(",", fieldsNames);
-      String sObjectName = sObjectDescriptor.getName();
-
-      List<List<Map<String, ?>>> partitions =
-        Lists.partition(fetchedIdList, SalesforceSourceConstants.WIDE_QUERY_MAX_BATCH_COUNT);
+      partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
+        sObjectDescriptor = SObjectDescriptor.fromQuery(query);
+      fieldsNames = sObjectDescriptor.getFieldsNames();
+      fields = String.join(",", fieldsNames);
+      sObjectName = sObjectDescriptor.getName();
       LOG.debug("Number of partitions to be fetched for wide object: '{}'", partitions.size());
-
-      // Process partitions with batches sized to adhere to API limits and optimize memory usage.
-      // [CDAP]TODO: Address issues while handling large datasets.
-      results = partitions.parallelStream()
-          .flatMap(partition -> processPartition(partnerConnection, fields, sObjectName,
-              partition, sObjectDescriptor).stream())
-          .collect(Collectors.toList());
-
-      if (results == null) {
-        LOG.warn("Result list is null after processing partitions.");
-        results = new ArrayList<>();
-      }
-
-      return this;
     } catch (ConnectionException e) {
       String errorMessage = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       throw new RuntimeException(
@@ -108,12 +104,35 @@ public class SalesforceWideRecordReader extends SalesforceBulkRecordReader {
           errorMessage),
         e);
     }
+
+    batchIterator = partitions.iterator();
+
+    // initialize the 1st batch
+    results = fetchBatchRecords();
+
+    return this;
+  }
+
+  public List<Map<String, ?>> fetchBatchRecords() {
+    List<Map<String, ?>> idList = batchIterator.next();
+    LOG.info("Fetching batch of {} records from {}.", idList.size(), sObjectName);
+    return processPartition(partnerConnection, fields, sObjectName, idList, sObjectDescriptor);
   }
 
   @Override
   public boolean nextKeyValue() {
-    if (results.size() == index) {
-      return false;
+    // If all current results are consumed, try to load the next batch
+    if (index >= results.size()) {
+      if (!batchIterator.hasNext()) {
+        return false;
+      }
+
+      results = fetchBatchRecords();
+      index = 0;
+
+      if (results.isEmpty()) {
+        return false;
+      }
     }
     value = results.get(index++);
     return true;

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReaderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.salesforce.plugin.source.batch;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.junit.Test;
+import org.mockito.internal.util.reflection.FieldSetter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SalesforceWideRecordReaderTest {
+  @Test
+  public void testWideRecordReader_withOutputRecords() throws Exception {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("Id", Schema.of(Schema.Type.STRING)));
+    SoapRecordToMapTransformer transformer = mock(SoapRecordToMapTransformer.class);
+    SalesforceWideRecordReader reader = new SalesforceWideRecordReader(schema, "SELECT Id FROM Account", transformer);
+
+    Map<String, Object> mockRecord = new HashMap<>();
+    mockRecord.put("Id", "id_123");
+
+    List<Map<String, ?>> results = new ArrayList<>();
+    results.add(mockRecord);
+
+    FieldSetter.setField(reader, SalesforceWideRecordReader.class.getDeclaredField("results"), results);
+    FieldSetter.setField(reader, SalesforceWideRecordReader.class.getDeclaredField("batchIterator"),
+      Collections.<List<Map<String, ?>>>emptyIterator());
+
+    assertEquals(0.0f, reader.getProgress(), 0.0001);
+
+    assert reader.nextKeyValue();
+    Map<String, ?> value = reader.getCurrentValue();
+    assertEquals("id_123", value.get("Id"));
+    assert value.containsKey("Id");
+    assertEquals(1.0f, reader.getProgress(), 0.0001);
+    assert !reader.nextKeyValue();
+    assertEquals("id_123", reader.getCurrentValue().get("Id"));
+  }
+
+  @Test
+  public void testWideRecordReader_fetchBatchRecordsCalledExpectedNumberOfTimes() throws Exception {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("Id", Schema.of(Schema.Type.STRING)));
+    SoapRecordToMapTransformer transformer = mock(SoapRecordToMapTransformer.class);
+    SalesforceWideRecordReader reader = spy(new SalesforceWideRecordReader(
+      schema, "SELECT Id FROM Account", transformer));
+
+    doNothing().when(reader).initialize(any(InputSplit.class), any(TaskAttemptContext.class));
+
+    List<List<Map<String, ?>>> mockPartitions = Arrays.asList(
+      Collections.singletonList(Collections.singletonMap("Id", "id_1")),
+      Collections.singletonList(Collections.singletonMap("Id", "id_2")),
+      Collections.singletonList(Collections.singletonMap("Id", "id_3"))
+    );
+
+    Iterator<List<Map<String, ?>>> batchIterator = mockPartitions.iterator();
+    FieldSetter.setField(reader, SalesforceWideRecordReader.class.getDeclaredField("batchIterator"), batchIterator);
+
+    AtomicInteger batchIndex = new AtomicInteger(0);
+    doAnswer(invocation -> {
+      int index = batchIndex.getAndIncrement();
+      if (index < mockPartitions.size()) {
+        return mockPartitions.get(index);
+      } else {
+        return Collections.emptyList();
+      }
+    }).when(reader).fetchBatchRecords();
+
+    FieldSetter.setField(reader, SalesforceWideRecordReader.class.getDeclaredField("results"), new ArrayList<>());
+    FieldSetter.setField(reader, SalesforceWideRecordReader.class.getDeclaredField("index"), 0);
+
+    List<Map<String, ?>> readRecords = new ArrayList<>();
+    while (reader.nextKeyValue()) {
+      readRecords.add(reader.getCurrentValue());
+    }
+
+    verify(reader, times(4)).fetchBatchRecords();
+    assertEquals(3, readRecords.size());
+  }
+}


### PR DESCRIPTION
Currently records from a single batch are being read in a parallel stream processing and the result is being stored in its entirety. This could lead to out of memory(OOM). 

The fix is to ensure that the batches are being read with the help of an iterator rather storing the entire result. Made the changes accordingly to `SalesforceWideRecordReader.java` 

Validation has been done by making a query of length more than 20k and ensuring the pipeline passes.

JIRA: https://cdap.atlassian.net/browse/PLUGIN-1897