### PR TITLE
Unwrap FailsafeException in BulkConnectionRetryWrapper

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
@@ -59,14 +59,21 @@ public class BulkConnectionRetryWrapper {
     if (!retryOnBackendError) {
       return bulkConnection.createJob(jobInfo);
     }
-    Object resultJobInfo = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while creating job."))
-        .get(() -> {
-          try {
-            return bulkConnection.createJob(jobInfo);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object resultJobInfo;
+    try {
+      resultJobInfo = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while creating job.")).get(() -> {
+        try {
+          return bulkConnection.createJob(jobInfo);
+        } catch (AsyncApiException e) {
+          throw new SalesforceQueryExecutionException(e);
+        }
+      });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (JobInfo) resultJobInfo;
   }
 
@@ -74,15 +81,23 @@ public class BulkConnectionRetryWrapper {
     if (!retryOnBackendError) {
       return bulkConnection.getJobStatus(jobId);
     }
-    Object resultJobInfo = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting job status."))
-        .get(() -> {
-          try {
-            return bulkConnection.getJobStatus(jobId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object resultJobInfo;
+    try {
+      resultJobInfo  = Failsafe.with(retryPolicy)
+          .onFailure(event -> LOG.info("Failed while getting job status."))
+          .get(() -> {
+            try {
+              return bulkConnection.getJobStatus(jobId);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (JobInfo) resultJobInfo;
   }
 
@@ -91,30 +106,44 @@ public class BulkConnectionRetryWrapper {
       bulkConnection.updateJob(jobInfo);
       return;
     }
-    Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while updating job."))
-        .get(() -> {
-          try {
-            return bulkConnection.updateJob(jobInfo);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    try {
+      Failsafe.with(retryPolicy)
+          .onFailure(event -> LOG.info("Failed while updating job."))
+          .get(() -> {
+            try {
+              return bulkConnection.updateJob(jobInfo);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
   }
 
   public BatchInfoList getBatchInfoList(String jobId) throws AsyncApiException {
     if (!retryOnBackendError) {
       return bulkConnection.getBatchInfoList(jobId);
     }
-    Object batchInfoList = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting batch info list."))
-        .get(() -> {
-          try {
-            return bulkConnection.getBatchInfoList(jobId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object batchInfoList;
+    try {
+      batchInfoList = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while getting batch info list."))
+          .get(() -> {
+            try {
+              return bulkConnection.getBatchInfoList(jobId);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (BatchInfoList) batchInfoList;
   }
 
@@ -122,15 +151,22 @@ public class BulkConnectionRetryWrapper {
     if (!retryOnBackendError) {
       return bulkConnection.getBatchInfo(jobId, batchId);
     }
-    Object batchInfo = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting batch status."))
-        .get(() -> {
-          try {
-            return bulkConnection.getBatchInfo(jobId, batchId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object batchInfo;
+    try {
+      batchInfo = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while getting batch status."))
+          .get(() -> {
+            try {
+              return bulkConnection.getBatchInfo(jobId, batchId);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (BatchInfo) batchInfo;
   }
 
@@ -138,15 +174,22 @@ public class BulkConnectionRetryWrapper {
     if (!retryOnBackendError) {
       return bulkConnection.getBatchResultStream(jobId, batchId);
     }
-    Object inputStream = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting batch result stream."))
-        .get(() -> {
-          try {
-            return bulkConnection.getBatchResultStream(jobId, batchId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object inputStream;
+    try {
+      inputStream = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while getting batch result stream."))
+          .get(() -> {
+            try {
+              return bulkConnection.getBatchResultStream(jobId, batchId);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (InputStream) inputStream;
   }
 
@@ -154,15 +197,22 @@ public class BulkConnectionRetryWrapper {
     if (!retryOnBackendError) {
       return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
     }
-    Object inputStream = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting query result stream."))
-        .get(() -> {
-          try {
-            return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object inputStream;
+    try {
+      inputStream = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while getting query result stream."))
+          .get(() -> {
+            try {
+              return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (InputStream) inputStream;
   }
 
@@ -171,16 +221,41 @@ public class BulkConnectionRetryWrapper {
     if (!retryOnBackendError) {
       return createBatchFromStreamI(query, job);
     }
-    Object batchInfo = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while creating batch from stream."))
-        .get(() -> {
-          try {
-            return createBatchFromStreamI(query, job);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    Object batchInfo;
+    try {
+      batchInfo = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while creating batch from stream."))
+          .get(() -> {
+            try {
+              return createBatchFromStreamI(query, job);
+            } catch (AsyncApiException e) {
+              throw new SalesforceQueryExecutionException(e);
+            }
+          });
+    } catch (FailsafeException fse) {
+      if (unwrapFailsafeException(fse) instanceof AsyncApiException) {
+        throw (AsyncApiException) unwrapFailsafeException(fse);
+      }
+      throw new RuntimeException(unwrapFailsafeException(fse)); // wrap as RuntimeException if not AsyncApiException
+    }
     return (BatchInfo) batchInfo;
+  }
+
+  private static Exception unwrapFailsafeException(FailsafeException e) {
+    if (e.getCause() instanceof Exception) {
+      Exception innerException = (Exception) e.getCause();
+      if (innerException instanceof SalesforceQueryExecutionException) {
+        return unwrapSalesforceQueryExecutionException((SalesforceQueryExecutionException) innerException);
+      }
+      return innerException;
+    }
+    return e;
+  }
+
+  private static Exception unwrapSalesforceQueryExecutionException(SalesforceQueryExecutionException e) {
+    if (e.getCause() instanceof AsyncApiException) {
+      return (AsyncApiException) e.getCause();
+    }
+    return e;
   }
 
   private BatchInfo createBatchFromStreamI(String query, JobInfo job) throws

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
@@ -321,7 +321,7 @@ public class SalesforceBulkRecordReaderTest {
    * The FailsafeException is thrown as retry limit gets exceeded.
    * The retry policy is correctly configured with the specified configurations.
    */
-  @Test(expected = FailsafeException.class)
+  @Test(expected = AsyncApiException.class)
   public void testRetryMechanism() throws Exception {
     Long initialRetryDuration = 5L;
     Long maxRetryDuration = 10L;
@@ -370,7 +370,7 @@ public class SalesforceBulkRecordReaderTest {
     reader.setupParser();
   }
 
-  @Test (expected = FailsafeException.class)
+  @Test (expected = AsyncApiException.class)
   public void testSetupParserWithoutRetry() throws Exception {
     String csvString1 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
       "\"0061i000003XNcBAAW\",\"false\",\"1500.0\",\"2019-02-22T07:03:21.000Z\",\"2019-01-01\",\"12:00:30.000Z\"\n";


### PR DESCRIPTION
## Description

Remove FailsafeException and SalesforceQueryExecutionException from logs by unwrapping them.

Ref PR: https://github.com/data-integrations/salesforce/pull/283
Ref Comment Req : https://github.com/data-integrations/salesforce/pull/283#issuecomment-2944292940



## Test

![image](https://github.com/user-attachments/assets/fb8fcf9c-586f-42d2-be71-5fd91ea5f92c)

```
2025-06-12 10:55:06,457 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@100] - Spark program 'phase-1' failed with error: Stage 'Salesforce' encountered : java.lang.RuntimeException: Failed to run a Salesforce bulk query (SELECT Id,IsDeleted,AccountId,RecordTypeId,IsPrivate,Name,Description,StageName,Amount,Probability,CloseDate,Type,NextStep,LeadSource,IsClosed,IsWon,ForecastCategory,ForecastCategoryName,CampaignId,HasOpportunityLineItem,Pricebook2Id,OwnerId,CreatedDate,CreatedById,LastModifiedDate,LastModifiedById,SystemModstamp,LastActivityDate,PushCount,LastStageChangeDate,FiscalQuarter,FiscalYear,Fiscal,ContactId,LastViewedDate,LastReferencedDate,HasOpenActivity,HasOverdueTask,LastAmountChangedHistoryId,LastCloseDateChangedHistoryId,Follow_Up__c,npe01__Member_Level__c,npe01__Membership_Origin__c,npe01__Number_of_Payments__c,npe01__Contact_Id_for_Role__c,npe01__Do_Not_Automatically_Create_Payment__c,npe01__Membership_End_Date__c,npe01__Membership_Start_Date__c,npe01__Amount_Outstanding__c,npe01__Is_Opp_From_Individual__c,npe01__Amount_Written_Off__c,npe01__Payments_Made__c,npo02__CombinedRollupFieldset__c,npo02__systemHouseholdContactRoleProcessor__c,npe03__Recurring_Donation__c,npsp__Acknowledgment_Status__c,npsp__Gift_Strategy__c,npsp__In_Kind_Type__c,npsp__Matching_Gift_Status__c,npsp__Notification_Preference__c,npsp__Tribute_Notification_Status__c,npsp__Tribute_Type__c,npsp__Acknowledgment_Date__c,npsp__Ask_Date__c,npsp__Batch_Number__c,npsp__Batch__c,npsp__Closed_Lost_Reason__c,npsp__CommitmentId__c,npsp__DisableContactRoleAutomation__c,npsp__Fair_Market_Value__c,npsp__Grant_Contract_Date__c,npsp__Grant_Contract_Number__c,npsp__Grant_Period_End_Date__c,npsp__Grant_Period_Start_Date__c,npsp__Grant_Program_Area_s__c,npsp__Grant_Requirements_Website__c,npsp__Honoree_Contact__c,npsp__Honoree_Information__c,npsp__Honoree_Name__c,npsp__In_Kind_Description__c,npsp__In_Kind_Donor_Declared_Value__c,npsp__Is_Grant_Renewal__c,npsp__Matching_Gift_Account__c,npsp__Matching_Gift_Employer__c,npsp__Matching_Gift__c,npsp__Notification_Message__c,npsp__Notification_Recipient_Contact__c,npsp__Notification_Recipient_Email__c,npsp__Notification_Recipient_Information__c,npsp__Notification_Recipient_Name__c,npsp__Previous_Grant_Opportunity__c,npsp__Primary_Contact_Campaign_Member_Status__c,npsp__Primary_Contact__c,npsp__Qualified_Date__c,npsp__Recurring_Donation_Installment_Number__c,npsp__Requested_Amount__c,npsp__Tribute_Notification_Date__c,npsp__Recurring_Donation_Installment_Name__c,npsp__Next_Grant_Deadline_Due_Date__c FROM Opportunity): ClientInputError : Failed to create job . Please check the system logs for more details.
io.cdap.cdap.api.exception.WrappedStageException: Stage 'Salesforce' encountered : java.lang.RuntimeException: Failed to run a Salesforce bulk query (SELECT Id,IsDeleted,AccountId,RecordTypeId,IsPrivate,Name,Description,StageName,Amount,Probability,CloseDate,Type,NextStep,LeadSource,IsClosed,IsWon,ForecastCategory,ForecastCategoryName,CampaignId,HasOpportunityLineItem,Pricebook2Id,OwnerId,CreatedDate,CreatedById,LastModifiedDate,LastModifiedById,SystemModstamp,LastActivityDate,PushCount,LastStageChangeDate,FiscalQuarter,FiscalYear,Fiscal,ContactId,LastViewedDate,LastReferencedDate,HasOpenActivity,HasOverdueTask,LastAmountChangedHistoryId,LastCloseDateChangedHistoryId,Follow_Up__c,npe01__Member_Level__c,npe01__Membership_Origin__c,npe01__Number_of_Payments__c,npe01__Contact_Id_for_Role__c,npe01__Do_Not_Automatically_Create_Payment__c,npe01__Membership_End_Date__c,npe01__Membership_Start_Date__c,npe01__Amount_Outstanding__c,npe01__Is_Opp_From_Individual__c,npe01__Amount_Written_Off__c,npe01__Payments_Made__c,npo02__CombinedRollupFieldset__c,npo02__systemHouseholdContactRoleProcessor__c,npe03__Recurring_Donation__c,npsp__Acknowledgment_Status__c,npsp__Gift_Strategy__c,npsp__In_Kind_Type__c,npsp__Matching_Gift_Status__c,npsp__Notification_Preference__c,npsp__Tribute_Notification_Status__c,npsp__Tribute_Type__c,npsp__Acknowledgment_Date__c,npsp__Ask_Date__c,npsp__Batch_Number__c,npsp__Batch__c,npsp__Closed_Lost_Reason__c,npsp__CommitmentId__c,npsp__DisableContactRoleAutomation__c,npsp__Fair_Market_Value__c,npsp__Grant_Contract_Date__c,npsp__Grant_Contract_Number__c,npsp__Grant_Period_End_Date__c,npsp__Grant_Period_Start_Date__c,npsp__Grant_Program_Area_s__c,npsp__Grant_Requirements_Website__c,npsp__Honoree_Contact__c,npsp__Honoree_Information__c,npsp__Honoree_Name__c,npsp__In_Kind_Description__c,npsp__In_Kind_Donor_Declared_Value__c,npsp__Is_Grant_Renewal__c,npsp__Matching_Gift_Account__c,npsp__Matching_Gift_Employer__c,npsp__Matching_Gift__c,npsp__Notification_Message__c,npsp__Notification_Recipient_Contact__c,npsp__Notification_Recipient_Email__c,npsp__Notification_Recipient_Information__c,npsp__Notification_Recipient_Name__c,npsp__Previous_Grant_Opportunity__c,npsp__Primary_Contact_Campaign_Member_Status__c,npsp__Primary_Contact__c,npsp__Qualified_Date__c,npsp__Recurring_Donation_Installment_Number__c,npsp__Requested_Amount__c,npsp__Tribute_Notification_Date__c,npsp__Recurring_Donation_Installment_Name__c,npsp__Next_Grant_Deadline_Due_Date__c FROM Opportunity): ClientInputError : Failed to create job 
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.prepareRun(WrappedBatchSource.java:52)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.prepareRun(WrappedBatchSource.java:35)
	at io.cdap.cdap.etl.common.submit.SubmitterPlugin.lambda$prepareRun$2(SubmitterPlugin.java:74)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$execute$5(AbstractContext.java:558)
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.finishExecute(Transactions.java:234)
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.execute(Transactions.java:221)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:554)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:540)
	at io.cdap.cdap.app.runtime.spark.BasicSparkClientContext.execute(BasicSparkClientContext.java:357)
	at io.cdap.cdap.etl.common.submit.SubmitterPlugin.prepareRun(SubmitterPlugin.java:72)
	at io.cdap.cdap.etl.common.submit.PipelinePhasePreparer.prepare(PipelinePhasePreparer.java:158)
	at io.cdap.cdap.etl.spark.AbstractSparkPreparer.prepare(AbstractSparkPreparer.java:87)
	at io.cdap.cdap.etl.spark.batch.SparkPreparer.prepare(SparkPreparer.java:94)
	at io.cdap.cdap.etl.spark.batch.ETLSpark.initialize(ETLSpark.java:131)
	at io.cdap.cdap.api.spark.AbstractSpark.initialize(AbstractSpark.java:131)
	at io.cdap.cdap.api.spark.AbstractSpark.initialize(AbstractSpark.java:33)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService$1.initialize(SparkRuntimeService.java:192)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService$1.initialize(SparkRuntimeService.java:187)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$initializeProgram$8(AbstractContext.java:650)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.initializeProgram(AbstractContext.java:647)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.initialize(SparkRuntimeService.java:550)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.startUp(SparkRuntimeService.java:234)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: Failed to run a Salesforce bulk query (SELECT Id,IsDeleted,AccountId,RecordTypeId,IsPrivate,Name,Description,StageName,Amount,Probability,CloseDate,Type,NextStep,LeadSource,IsClosed,IsWon,ForecastCategory,ForecastCategoryName,CampaignId,HasOpportunityLineItem,Pricebook2Id,OwnerId,CreatedDate,CreatedById,LastModifiedDate,LastModifiedById,SystemModstamp,LastActivityDate,PushCount,LastStageChangeDate,FiscalQuarter,FiscalYear,Fiscal,ContactId,LastViewedDate,LastReferencedDate,HasOpenActivity,HasOverdueTask,LastAmountChangedHistoryId,LastCloseDateChangedHistoryId,Follow_Up__c,npe01__Member_Level__c,npe01__Membership_Origin__c,npe01__Number_of_Payments__c,npe01__Contact_Id_for_Role__c,npe01__Do_Not_Automatically_Create_Payment__c,npe01__Membership_End_Date__c,npe01__Membership_Start_Date__c,npe01__Amount_Outstanding__c,npe01__Is_Opp_From_Individual__c,npe01__Amount_Written_Off__c,npe01__Payments_Made__c,npo02__CombinedRollupFieldset__c,npo02__systemHouseholdContactRoleProcessor__c,npe03__Recurring_Donation__c,npsp__Acknowledgment_Status__c,npsp__Gift_Strategy__c,npsp__In_Kind_Type__c,npsp__Matching_Gift_Status__c,npsp__Notification_Preference__c,npsp__Tribute_Notification_Status__c,npsp__Tribute_Type__c,npsp__Acknowledgment_Date__c,npsp__Ask_Date__c,npsp__Batch_Number__c,npsp__Batch__c,npsp__Closed_Lost_Reason__c,npsp__CommitmentId__c,npsp__DisableContactRoleAutomation__c,npsp__Fair_Market_Value__c,npsp__Grant_Contract_Date__c,npsp__Grant_Contract_Number__c,npsp__Grant_Period_End_Date__c,npsp__Grant_Period_Start_Date__c,npsp__Grant_Program_Area_s__c,npsp__Grant_Requirements_Website__c,npsp__Honoree_Contact__c,npsp__Honoree_Information__c,npsp__Honoree_Name__c,npsp__In_Kind_Description__c,npsp__In_Kind_Donor_Declared_Value__c,npsp__Is_Grant_Renewal__c,npsp__Matching_Gift_Account__c,npsp__Matching_Gift_Employer__c,npsp__Matching_Gift__c,npsp__Notification_Message__c,npsp__Notification_Recipient_Contact__c,npsp__Notification_Recipient_Email__c,npsp__Notification_Recipient_Information__c,npsp__Notification_Recipient_Name__c,npsp__Previous_Grant_Opportunity__c,npsp__Primary_Contact_Campaign_Member_Status__c,npsp__Primary_Contact__c,npsp__Qualified_Date__c,npsp__Recurring_Donation_Installment_Number__c,npsp__Requested_Amount__c,npsp__Tribute_Notification_Date__c,npsp__Recurring_Donation_Installment_Name__c,npsp__Next_Grant_Deadline_Due_Date__c FROM Opportunity): ClientInputError : Failed to create job 
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.getBatches(SalesforceSplitUtil.java:103)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.getQuerySplits(SalesforceSplitUtil.java:72)
	at io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource.getSplits(SalesforceBatchSource.java:171)
	at io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource.prepareRun(SalesforceBatchSource.java:142)
	at io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBatchSource.prepareRun(SalesforceBatchSource.java:63)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.lambda$prepareRun$0(WrappedBatchSource.java:53)
	at io.cdap.cdap.etl.common.plugin.Caller$1.call(Caller.java:30)
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:62)
	... 26 common frames omitted
Caused by: com.sforce.async.AsyncApiException: ClientInputError : Failed to create job 
	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.lambda$createJob$1(BulkConnectionRetryWrapper.java:71)
	at dev.failsafe.Functions.lambda$toCtxSupplier$11(Functions.java:243)
	at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
	at dev.failsafe.internal.RetryPolicyExecutor.lambda$apply$0(RetryPolicyExecutor.java:74)
	at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:187)
	at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:376)
	at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:112)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.createJob(BulkConnectionRetryWrapper.java:66)
	at io.cdap.plugin.salesforce.SalesforceBulkUtil.createJob(SalesforceBulkUtil.java:81)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.runBulkQuery(SalesforceSplitUtil.java:124)
	at io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil.getBatches(SalesforceSplitUtil.java:97)
	... 33 common frames omitted
Caused by: java.io.IOException: Simulated IOException for testing retry logic
	at io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper.lambda$createJob$1(BulkConnectionRetryWrapper.java:69)
	... 43 common frames omitted
```