### PR TITLE
Fix: Vulnerability for json_version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <commons.csv.version>1.6</commons.csv.version>
     <jackson.version>1.9.13</jackson.version>
     <jackson2.version>2.17.1</jackson2.version>
-    <json.version>20180813</json.version>
+    <json.version>20231013</json.version>
     <awaitility.version>3.1.6</awaitility.version>
     <commons-logging.version>1.2</commons-logging.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>


### PR DESCRIPTION
Issue:
Addressed Denial of Service (DoS) vulnerabilities in the org.json:json library and related components. JSON-Java versions up to and including 20230618 contained a parser bug allowing modestly sized input to cause excessive memory consumption. Additionally, a stack overflow in the XML.toJSONObject component of hutool-json v5.8.10 and org.json:json versions prior to 20230227 allowed attackers to exploit crafted JSON or XML data to trigger DoS.

Root Cause :
Insufficient validation and resource management in the parser enabled malicious input to exhaust system memory or cause stack overflows.

Fix : Upgraded org.json:json to a secure version (20231013) .

JIRA Ticket : https://cdap.atlassian.net/browse/PLUGIN-1904