### PR TITLE
[PLUGIN-1904] Fix: Vulnerability for json_version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <commons.csv.version>1.6</commons.csv.version>
     <jackson.version>1.9.13</jackson.version>
     <jackson2.version>2.17.1</jackson2.version>
-    <json.version>20180813</json.version>
+    <json.version>20231013</json.version>
     <awaitility.version>3.1.6</awaitility.version>
     <commons-logging.version>1.2</commons-logging.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceUtil.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.reflect.ClassTag$;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -146,6 +147,13 @@ final class SalesforceStreamingSourceUtil {
           String.format("Field '%s' is of type '%s', but value found is '%s'",
                         field.getName(), fieldSchemaType, value));
       }
+    }
+
+    // NOTE: org.json >= 20230227 returns BigDecimal for all non-integer JSON numbers.
+    if (value instanceof BigDecimal && fieldSchemaType.equals(Schema.Type.DOUBLE)) {
+      // Avro Schema.Type.DOUBLE expects a Double instance (or primitive double) at serialization time,
+      // so converting BigDecimal → double for compatibility.
+      return ((BigDecimal) value).doubleValue();
     }
 
     return value;


### PR DESCRIPTION
Issue:
Addressed Denial of Service (DoS) vulnerabilities in the org.json:json library and related components. JSON-Java versions up to and including 20230618 contained a parser bug allowing modestly sized input to cause excessive memory consumption. Additionally, a stack overflow in the XML.toJSONObject component of hutool-json v5.8.10 and org.json:json versions prior to 20231013 allowed attackers to exploit crafted JSON or XML data to trigger DoS.

Root Cause :
Insufficient validation and resource management in the parser enabled malicious input to exhaust system memory or cause stack overflows.

Fix : Upgraded org.json:json to a secure version (20231013) .

JIRA Ticket : https://cdap.atlassian.net/browse/PLUGIN-1904