### PR TITLE
Fix: Vulnerability for guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -754,14 +754,6 @@
         </plugins>
       </build>
       <dependencyManagement>
-        <dependencies>
-          <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
-            <scope>compile</scope>
-          </dependency>
-        </dependencies>
       </dependencyManagement>
       <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,16 @@
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.1.3-jre</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -117,6 +127,12 @@
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>
       <version>${hydrator.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -322,6 +338,10 @@
       <scope>test</scope>
       <exclusions>
         <exclusion>
+          <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-formats</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.twill</groupId>
           <artifactId>twill-core</artifactId>
         </exclusion>
@@ -370,6 +390,12 @@
       <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
@@ -412,6 +438,12 @@
       <artifactId>cdap-data-streams2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -754,6 +786,14 @@
         </plugins>
       </build>
       <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+            <scope>compile</scope>
+          </dependency>
+        </dependencies>
       </dependencyManagement>
       <dependencies>
         <dependency>


### PR DESCRIPTION
Issue:
Resolved a high-severity information disclosure vulnerability (CVE-2023-2976) related to insecure temporary file handling in the FileBackedOutputStream class of the Guava library (com.google.guava:guava). This vulnerability affects versions 1.0 through 31.1 on Unix-based systems and Android Ice Cream Sandwich. In vulnerable versions, temporary files were created in the system's default temporary directory (/tmp), allowing local users or applications with access to the directory to potentially read or tamper with those files.

Root Cause:
Guava used Java's default temporary directory for storing files without proper isolation, which could expose sensitive data in shared environments.

Fix:
Removed the explicit dependency on Guava from the Salesforce plugin 