### PR TITLE
PLUGIN-1917: Exclude jackson-core to fix CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,12 @@
       <groupId>com.force.api</groupId>
       <artifactId>force-wsc</artifactId>
       <version>${salesforce.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.force.api</groupId>


### PR DESCRIPTION
**JIRA**: [PLUGIN-1917](https://cdap.atlassian.net/browse/PLUGIN-1917)

**Issue:** : A flaw was found in the Jackson-core JsonLocation._appendSourceDesc method. This vulnerability allows up to 500 bytes of unintended memory content to be included in exception messages. This issue may lead to unintended information disclosure. MITIGATION: If upgrading is not immediately possible, applications can mitigate the issue by disabling exception message exposure to clients to avoid returning parsing exception messages in HTTP responses and/or disabling source inclusion in exceptions to prevent Jackson from embedding any source content in exception messages, avoiding leakage.

**CVE**: CVE-2025-49128
**Severity**: Medium
**Version Affected**: 2.12.3

Fix: Exclude the `jackson-core` dependency transitively fetched from `force-wsc`

<img width="721" height="92" alt="image" src="https://github.com/user-attachments/assets/75537679-7f43-4c24-aa24-586bb6af6a08" />


[PLUGIN-1917]: https://cdap.atlassian.net/browse/PLUGIN-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ