### PR TITLE
[PLUGIN-1918] Fix: Vulnerability for commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <hadoop.version>2.10.2</hadoop.version>
     <spark2.version>2.1.3</spark2.version>
     <hydrator.version>2.10.0</hydrator.version>
-    <commons.version>3.8.1</commons.version>
+    <commons.version>3.18.0</commons.version>
     <salesforce.api.version>62.0.0</salesforce.api.version>
     <cometd.java.client.version>4.0.0</cometd.java.client.version>
     <antlr.version>4.7.2</antlr.version>


### PR DESCRIPTION
Issue :
Commons-lang3 versions earlier than 3.18.0 (including 3.8.1) contain a vulnerability (CVE-2025-48924) in the ClassUtils.getClass(...) method. Malicious or overly long input causes uncontrolled recursion, leading to a StackOverflowError and potential application crashes.

Root Cause :
The recursive logic fails to limit input length, causing stack exhaustion.

Fix :
Upgrade to commons-lang3 version 3.18.0, which resolves the issue by preventing infinite recursion.

Jira ticket :
https://cdap.atlassian.net/browse/PLUGIN-1918
