### PR TITLE
[Cherrypick] [Plugin-1908] Added retry logic for PartnerConnection

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/salesforcebatchsource/actions/SalesforcePropertiesPageActions.java
+++ b/src/e2e-test/java/io/cdap/plugin/salesforcebatchsource/actions/SalesforcePropertiesPageActions.java
@@ -128,10 +128,11 @@ public class SalesforcePropertiesPageActions {
 
   private static AuthenticatorCredentials setAuthenticationCredentialsOfAdminUser() {
     return new AuthenticatorCredentials(null, PluginPropertyUtils.pluginProp("admin.username"),
-      PluginPropertyUtils.pluginProp("admin.password"),
-      PluginPropertyUtils.pluginProp("admin.consumer.key"),
-      PluginPropertyUtils.pluginProp("admin.consumer.secret"),
-      PluginPropertyUtils.pluginProp("login.url"), null, null, null, null
+                                        PluginPropertyUtils.pluginProp("admin.password"),
+                                        PluginPropertyUtils.pluginProp("admin.consumer.key"),
+                                        PluginPropertyUtils.pluginProp("admin.consumer.secret"),
+                                        PluginPropertyUtils.pluginProp("login.url"), null, null, null, null,
+                                        null, null, null, true
     );
   }
 

--- a/src/e2e-test/java/io/cdap/plugin/utils/SalesforceClient.java
+++ b/src/e2e-test/java/io/cdap/plugin/utils/SalesforceClient.java
@@ -181,7 +181,8 @@ public class SalesforceClient {
         Authenticator.createConnectorConfig(AuthenticatorCredentials.fromParameters(USERNAME, PASSWORD + SECURITYTOKEN,
                                                                          CLIENTID, CLIENTSECRET, PluginPropertyUtils.
                                                                            pluginProp("login.url"),
-                                                                         30000, 3600, "")));
+                                                                                    30000, 3600, "", 5L, 10L, 5,
+                                                                                    true)));
 
       QueryResult queryResult = SalesforceStreamingSourceConfig.runQuery(
         partnerConnection,

--- a/src/main/java/com/sforce/soap/partner/PartnerConnectionRetryWrapper.java
+++ b/src/main/java/com/sforce/soap/partner/PartnerConnectionRetryWrapper.java
@@ -1,0 +1,531 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.sforce.soap.partner;
+
+import com.sforce.soap.partner.fault.ApiFault;
+import com.sforce.soap.partner.sobject.SObject;
+import com.sforce.ws.ConnectionException;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException;
+
+import java.net.SocketTimeoutException;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class that wraps Salesforce PartnerConnection calls with retry logic using Failsafe.
+ */
+public class PartnerConnectionRetryWrapper extends PartnerConnection {
+
+  private final RetryPolicy<Object> retryPolicy;
+  private static final Set<String> RETRYABLE_CONNECTION_ERRORS = new HashSet<>(Arrays.asList(
+    "connection refused",
+    "connection timed out",
+    "failed to send request",
+    "socket timeout",
+    "read timed out",
+    "connection reset"
+  ));
+
+  private static final Set<String> RETRYABLE_API_FAULT_ERRORS = new HashSet<>(Collections.singletonList(
+    "SERVER_UNAVAILABLE"
+  ));
+  private final PartnerConnection delegate;
+
+  public PartnerConnectionRetryWrapper(PartnerConnection delegate, RetryPolicy<Object> retryPolicy) throws
+    ConnectionException {
+    super(delegate.getConfig());
+    this.delegate = delegate;
+    this.retryPolicy = retryPolicy;
+  }
+
+  @Override
+  public DescribeTab[] describeAllTabs() throws ConnectionException {
+    return executeWithRetry(delegate::describeAllTabs, "The describeAllTabs method returned a null result.");
+  }
+
+  @Override
+  public DescribeDataCategoryGroupStructureResult[]
+  describeDataCategoryGroupStructures(DataCategoryGroupSobjectTypePair[] pairs, boolean topCategoriesOnly) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeDataCategoryGroupStructures(pairs, topCategoriesOnly),
+                            "The describeDataCategoryGroupStructures method returned a null result.");
+  }
+
+  @Override
+  public DescribeDataCategoryGroupResult[] describeDataCategoryGroups(String[] sObjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeDataCategoryGroups(sObjectType),
+                            "The describeDataCategoryGroups method returned a null result.");
+  }
+
+  @Override
+  public FindDuplicatesResult[] findDuplicates(SObject[] sObjects) throws ConnectionException {
+    return executeWithRetry(() -> delegate.findDuplicates(sObjects),
+                            "The findDuplicates method returned a null result.");
+  }
+
+  @Override
+  public ProcessResult[] process(ProcessRequest[] actions) throws ConnectionException {
+    return executeWithRetry(() -> delegate.process(actions),
+                            "The process method returned a null result.");
+  }
+
+  @Override
+  public DescribeGlobalResult describeGlobal() throws ConnectionException {
+    return executeWithRetry(delegate::describeGlobal, "The describeGlobal() method returned a null result.");
+  }
+
+  @Override
+  public GetUserInfoResult getUserInfo() throws ConnectionException {
+    return executeWithRetry(delegate::getUserInfo, "The UserInfo or OrganizationId is null.");
+  }
+
+  @Override
+  public DescribeGlobalTheme describeGlobalTheme() throws ConnectionException {
+    return executeWithRetry(delegate::describeGlobalTheme,
+                            "The describeGlobalTheme method returned a null result.");
+  }
+
+  @Override
+  public DescribeApprovalLayoutResult describeApprovalLayout(String sObjectType, String[] approvalProcessNames) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeApprovalLayout(sObjectType, approvalProcessNames),
+                            "The describeApprovalLayout method returned a null result.");
+  }
+
+  @Override
+  public DescribeCompactLayout[] describePrimaryCompactLayouts(String[] sObjectTypes) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describePrimaryCompactLayouts(sObjectTypes),
+                            "The describePrimaryCompactLayouts method returned a null result.");
+  }
+
+  @Override
+  public QueryResult queryMore(String queryLocator) throws ConnectionException {
+    return executeWithRetry(() -> delegate.queryMore(queryLocator),
+                            "The QueryMore returned a null result for locator used in query: " + queryLocator
+    );
+  }
+
+  @Override
+  public DescribeSearchableEntityResult[] describeSearchableEntities(boolean includeOnlyEntitiesWithTabs) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeSearchableEntities(includeOnlyEntitiesWithTabs),
+                            "The describeSearchableEntities method returned a null result.");
+  }
+
+  @Override
+  public DescribeLayoutResult describeLayout(String sObjectType, String layoutName, String[] recordTypeIds) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeLayout(sObjectType, layoutName, recordTypeIds),
+                            "The describeLayout method returned a null result.");
+  }
+
+  @Override
+  public DescribeAppMenuResult describeAppMenu(AppMenuType appMenuType, String networkId) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeAppMenu(appMenuType, networkId),
+                            "The describeAppMenu method returned a null result.");
+  }
+
+  @Override
+  public DescribeLookupLayoutResult[] describeLookupLayouts(String[] sObjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeLookupLayouts(sObjectType),
+                            "The describeLookupLayouts method returned a null result.");
+  }
+
+  @Override
+  public LeadConvertResult[] convertLead(LeadConvert[] leadConverts) throws ConnectionException {
+    return executeWithRetry(() -> delegate.convertLead(leadConverts),
+                            "The convertLead method returned a null result.");
+  }
+
+  @Override
+  public DescribeSoqlListViewResult describeSObjectListViews(String sObjectType, boolean recentsOnly,
+                                                             ListViewIsSoqlCompatible isSoqlCompatible,
+                                                             int limit, int offset) throws ConnectionException {
+    return executeWithRetry(
+      () -> delegate.describeSObjectListViews(sObjectType, recentsOnly, isSoqlCompatible, limit, offset),
+      "The describeSObjectListViews method returned a null result.");
+  }
+
+  @Override
+  public DeleteResult[] delete(String[] ids) throws ConnectionException {
+    return executeWithRetry(() -> delegate.delete(ids),
+                            "The delete method returned a null result.");
+  }
+
+  @Override
+  public LoginResult login(String username, String password) throws ConnectionException {
+    return executeWithRetry(() -> delegate.login(username, password),
+                            "The login method returned a null result.");
+  }
+
+  @Override
+  public QueryResult queryAll(String queryString) throws ConnectionException {
+    return executeWithRetry(() -> delegate.queryAll(queryString),
+                            "The queryAll method returned a null result.");
+  }
+
+  @Override
+  public SaveResult[] update(SObject[] sObjects) throws ConnectionException {
+    return executeWithRetry(() -> delegate.update(sObjects),
+                            "The update method returned a null result.");
+  }
+
+  @Override
+  public EmptyRecycleBinResult[] emptyRecycleBin(String[] ids) throws ConnectionException {
+    return executeWithRetry(() -> delegate.emptyRecycleBin(ids),
+                            "The emptyRecycleBin method returned a null result.");
+  }
+
+  @Override
+  public DescribeCompactLayoutsResult describeCompactLayouts(String sObjectType, String[] recordTypeIds) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeCompactLayouts(sObjectType, recordTypeIds),
+                            "The describeCompactLayouts method returned a null result.");
+  }
+
+  @Override
+  public ChangeOwnPasswordResult changeOwnPassword(String oldPassword, String newPassword) throws ConnectionException {
+    return executeWithRetry(() -> delegate.changeOwnPassword(oldPassword, newPassword),
+                            "The changeOwnPassword method returned a null result.");
+  }
+
+  @Override
+  public DescribeSoqlListViewResult describeSoqlListViews(DescribeSoqlListViewsRequest request) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeSoqlListViews(request),
+                            "The describeSoqlListViews method returned a null result.");
+  }
+
+  @Override
+  public DescribePathAssistantsResult describePathAssistants(String sObjectType, String picklistValue,
+                                                             String[] recordTypeIds) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describePathAssistants(sObjectType, picklistValue, recordTypeIds),
+                            "The describePathAssistants method returned a null result.");
+  }
+
+  @Override
+  public DescribeAvailableQuickActionResult[] describeAvailableQuickActions(String contextType) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeAvailableQuickActions(contextType),
+                            "The describeAvailableQuickActions method returned a null result.");
+  }
+
+  @Override
+  public GetDeletedResult getDeleted(String sObjectType, Calendar startDate, Calendar endDate) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.getDeleted(sObjectType, startDate, endDate),
+                            "The getDeleted method returned a null result.");
+  }
+
+  @Override
+  public DescribeTabSetResult[] describeTabs() throws ConnectionException {
+    return executeWithRetry(delegate::describeTabs,
+                            "The describeTabs method returned a null result.");
+  }
+
+  @Override
+  public QuickActionTemplateResult[] retrieveMassQuickActionTemplates(String quickActionName, String[] contextIds)
+    throws ConnectionException {
+    return executeWithRetry(() -> delegate.retrieveMassQuickActionTemplates(quickActionName, contextIds),
+                            "The retrieveMassQuickActionTemplates method returned a null result.");
+  }
+
+  @Override
+  public SearchResult search(String searchString) throws ConnectionException {
+    return executeWithRetry(() -> delegate.search(searchString),
+                            "The search method returned a null result.");
+  }
+
+  @Override
+  public SendEmailResult[] sendEmail(Email[] messages) throws ConnectionException {
+    return executeWithRetry(() -> delegate.sendEmail(messages),
+                            "The sendEmail method returned a null result.");
+  }
+
+  @Override
+  public GetUpdatedResult getUpdated(String sObjectType, Calendar startDate, Calendar endDate) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.getUpdated(sObjectType, startDate, endDate),
+                            "The getUpdated method returned a null result.");
+  }
+
+  @Override
+  public SendEmailResult[] sendEmailMessage(String[] ids) throws ConnectionException {
+    return executeWithRetry(() -> delegate.sendEmailMessage(ids),
+                            "The sendEmailMessage method returned a null result.");
+  }
+
+  @Override
+  public DescribeQuickActionResult[] describeQuickActionsForRecordType(String[] quickActions, String recordTypeId)
+    throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeQuickActionsForRecordType(quickActions, recordTypeId),
+                            "The describeQuickActionsForRecordType method returned a null result.");
+  }
+
+  @Override
+  public RenderEmailTemplateResult[] renderEmailTemplate(RenderEmailTemplateRequest[] renderRequests) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.renderEmailTemplate(renderRequests),
+                            "The renderEmailTemplate method returned a null result.");
+  }
+
+  @Override
+  public UpsertResult[] upsert(String externalIDFieldName, SObject[] sObjects) throws ConnectionException {
+    return executeWithRetry(() -> delegate.upsert(externalIDFieldName, sObjects),
+                            "The upsert method returned a null result.");
+  }
+
+  @Override
+  public QueryResult query(String queryString) throws ConnectionException {
+    return executeWithRetry(() -> delegate.query(queryString),
+                            "The query method returned a null result: " + queryString);
+  }
+
+  @Override
+  public DescribeQuickActionResult[] describeQuickActions(String[] quickActions) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeQuickActions(quickActions),
+                            "The describeQuickActions method returned a null result.");
+  }
+
+  @Override
+  public PerformQuickActionResult[] performQuickActions(PerformQuickActionRequest[] quickActions) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.performQuickActions(quickActions),
+                            "The performQuickActions method returned a null result.");
+  }
+
+  @Override
+  public DescribeSObjectResult[] describeSObjects(String[] sObjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeSObjects(sObjectType),
+                            "The describeSObjects returned a null result: " + Arrays.stream(sObjectType).collect(
+                              Collectors.toSet())
+    );
+  }
+
+  @Override
+  public KnowledgeSettings describeKnowledgeSettings() throws ConnectionException {
+    return executeWithRetry(delegate::describeKnowledgeSettings,
+                            "The describeKnowledgeSettings method returned a null result.");
+  }
+
+  @Override
+  public UndeleteResult[] undelete(String[] ids) throws ConnectionException {
+    return executeWithRetry(() -> delegate.undelete(ids),
+                            "The undelete method returned a null result.");
+  }
+
+  @Override
+  public SObject[] retrieve(String fieldList, String sObjectType, String[] ids) throws ConnectionException {
+    return executeWithRetry(() -> delegate.retrieve(fieldList, sObjectType, ids),
+                            "The Retrieve returned a null result for sObject: " + sObjectType
+    );
+  }
+
+  @Override
+  public DescribeThemeResult describeTheme(String[] sobjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeTheme(sobjectType),
+                            "The describeTheme method returned a null result.");
+  }
+
+  @Override
+  public DeleteByExampleResult[] deleteByExample(SObject[] sObjects) throws ConnectionException {
+    return executeWithRetry(() -> delegate.deleteByExample(sObjects),
+                            "The DeleteByExampleResult method returned a null result.");
+  }
+
+  @Override
+  public DescribeNounResult[] describeNouns(String[] nouns, boolean onlyRenamed, boolean includeFields) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeNouns(nouns, onlyRenamed, includeFields),
+                            "The DescribeNounResult method returned a null result.");
+  }
+
+  @Override
+  public FindDuplicatesResult[] findDuplicatesByIds(String[] ids) throws ConnectionException {
+    return executeWithRetry(() -> delegate.findDuplicatesByIds(ids),
+                            "The findDuplicatesByIds method returned a null result.");
+  }
+
+  @Override
+  public ExecuteListViewResult executeListView(ExecuteListViewRequest request) throws ConnectionException {
+    return executeWithRetry(() -> delegate.executeListView(request),
+                            "The executeListView method returned a null result.");
+  }
+
+  @Override
+  public RenderStoredEmailTemplateResult renderStoredEmailTemplate(RenderStoredEmailTemplateRequest request) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.renderStoredEmailTemplate(request),
+                            "The renderStoredEmailTemplate method returned a null result.");
+  }
+
+  @Override
+  public DescribeVisualForceResult describeVisualForce(boolean includeAllDetails, String namespacePrefix) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeVisualForce(includeAllDetails, namespacePrefix),
+                            "The describeVisualForce method returned a null result.");
+  }
+
+  @Override
+  public DescribeSObjectResult describeSObject(String sObjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeSObject(sObjectType),
+                            "The describeSObject returned a null result: " + sObjectType);
+  }
+
+  @Override
+  public GetServerTimestampResult getServerTimestamp() throws ConnectionException {
+    return executeWithRetry(delegate::getServerTimestamp,
+                            "The getServerTimestamp method returned a null result.");
+  }
+
+  @Override
+  public QuickActionTemplateResult[] retrieveQuickActionTemplates(String[] quickActionNames, String contextId) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.retrieveQuickActionTemplates(quickActionNames, contextId),
+                            "The retrieveQuickActionTemplates method returned a null result.");
+  }
+
+  @Override
+  public SetPasswordResult setPassword(String userId, String password) throws ConnectionException {
+    return executeWithRetry(() -> delegate.setPassword(userId, password),
+                            "The setPassword method returned a null result.");
+  }
+
+  @Override
+  public ResetPasswordResult resetPassword(String userId) throws ConnectionException {
+    return executeWithRetry(() -> delegate.resetPassword(userId),
+                            "The resetPassword method returned a null result.");
+  }
+
+  @Override
+  public DescribeSoftphoneLayoutResult describeSoftphoneLayout() throws ConnectionException {
+    return executeWithRetry(delegate::describeSoftphoneLayout,
+                            "The describeSoftphoneLayout method returned a null result.");
+  }
+
+  @Override
+  public SaveResult[] create(SObject[] sObjects) throws ConnectionException {
+    return executeWithRetry(() -> delegate.create(sObjects),
+                            "The create method returned a null result.");
+  }
+
+  @Override
+  public DescribeSearchLayoutResult[] describeSearchLayouts(String[] sObjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeSearchLayouts(sObjectType),
+                            "The describeSearchLayouts method returned a null result.");
+  }
+
+  @Override
+  public MergeResult[] merge(MergeRequest[] request) throws ConnectionException {
+    return executeWithRetry(() -> delegate.merge(request),
+                            "The merge method returned a null result.");
+  }
+
+  @Override
+  public InvalidateSessionsResult[] invalidateSessions(String[] sessionIds) throws ConnectionException {
+    return executeWithRetry(() -> delegate.invalidateSessions(sessionIds),
+                            "The invalidateSessions method returned a null result.");
+  }
+
+  @Override
+  public DescribeListViewResult[] describeListViews(String[] sObjectType) throws ConnectionException {
+    return executeWithRetry(() -> delegate.describeListViews(sObjectType),
+                            "The describeListViews method returned a null result.");
+  }
+
+  @Override
+  public DescribeDataCategoryMappingResult[] describeDataCategoryMappings() throws ConnectionException {
+    return executeWithRetry(delegate::describeDataCategoryMappings,
+                            "The describeDataCategoryMappings method returned a null result.");
+  }
+
+  @Override
+  public void logout() throws ConnectionException {
+    delegate.logout();
+  }
+
+  @Override
+  public DescribeSearchScopeOrderResult[] describeSearchScopeOrder(boolean includeRealTimeEntities) throws
+    ConnectionException {
+    return executeWithRetry(() -> delegate.describeSearchScopeOrder(includeRealTimeEntities),
+                            "The describeSearchScopeOrder method returned a null result.");
+  }
+
+  /**
+   * Executes a Salesforce PartnerConnection operation with retry logic using the provided {@link RetryPolicy}.
+   * <p>
+   * This method wraps the execution in {@link Failsafe} to handle transient {@link ConnectionException}s
+   * and retries the operation if the exception is considered retryable.
+   * It also performs a null or custom result validation check, throwing an {@link IllegalArgumentException}
+   * if the result is invalid.
+   *
+   * @param operation    the Salesforce PartnerConnection operation to execute
+   * @param errorContext a descriptive message used when the result is null or fails the validation check
+   * @param <T>          the type of the result returned by the operation
+   * @return the result of the successful operation
+   * @throws ConnectionException      if the operation fails with a non-retryable {@link ConnectionException}
+   * @throws IllegalArgumentException if the result is null or fails the provided validation check
+   */
+  private <T> T executeWithRetry(Callable<T> operation, String errorContext) throws ConnectionException {
+    try {
+      return Failsafe.with(retryPolicy).get(() -> {
+        try {
+          T result = operation.call();
+          if (result == null) {
+            throw new IllegalArgumentException(errorContext);
+          }
+          return result;
+        } catch (ConnectionException e) {
+          if (isRetryableConnectionError(e)) {
+            throw new SalesforceQueryExecutionException(e);
+          }
+          throw e;
+        }
+      });
+    } catch (FailsafeException ex) {
+      if (ex.getCause() instanceof ConnectionException) {
+        throw (ConnectionException) ex.getCause();
+      }
+      throw ex;
+    }
+  }
+
+  public boolean isRetryableConnectionError(ConnectionException e) {
+    if (e.getCause() instanceof SocketTimeoutException) {
+      return true;
+    }
+    if (e.getCause() instanceof ApiFault) {
+      ApiFault apifault = (ApiFault) e.getCause();
+      return RETRYABLE_API_FAULT_ERRORS.contains(apifault.getExceptionCode().toString());
+    }
+    String error = e.getMessage();
+    if (error == null) {
+      return false;
+    }
+    error = error.toLowerCase();
+    return RETRYABLE_CONNECTION_ERRORS.stream()
+      .anyMatch(error::contains);
+  }
+}

--- a/src/main/java/io/cdap/plugin/salesforce/SObjectsDescribeResult.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SObjectsDescribeResult.java
@@ -63,7 +63,7 @@ public class SObjectsDescribeResult {
       DescribeSObjectResult[] describeSObjectResults = connection.describeSObjects(partition.toArray(new String[0]));
       Stream.of(describeSObjectResults)
         .forEach(result -> addSObjectDescribe(result.getName(), result.getFields(), objectToFieldMap));
-    }
+      }
     return new SObjectsDescribeResult(objectToFieldMap);
   }
 
@@ -213,11 +213,7 @@ public class SObjectsDescribeResult {
     // if SObject describe result is absent in cache, try to obtain it from Salesforce
     if (describe == null) {
       describe = connection.describeSObject(name);
-      if (describe == null) {
-        throw new IllegalArgumentException("Unable to describe SObject: " + name);
-      }
     }
-    // store describe result in cache for future re-use
     cache.put(name.toLowerCase(), describe);
     return describe;
   }

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
@@ -16,6 +16,7 @@
 package io.cdap.plugin.salesforce;
 
 import com.sforce.soap.partner.PartnerConnection;
+import com.sforce.soap.partner.PartnerConnectionRetryWrapper;
 import com.sforce.soap.partner.fault.IApiFault;
 import com.sforce.ws.ConnectionException;
 import com.sforce.ws.ConnectorConfig;
@@ -24,6 +25,7 @@ import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -42,7 +44,11 @@ public class SalesforceConnectionUtil {
   public static PartnerConnection getPartnerConnection(AuthenticatorCredentials credentials)
     throws ConnectionException {
     ConnectorConfig connectorConfig = Authenticator.createConnectorConfig(credentials);
-    return new PartnerConnection(connectorConfig);
+    return new PartnerConnectionRetryWrapper(new PartnerConnection(connectorConfig),
+                                             SalesforceSplitUtil.getRetryPolicy(credentials.getInitialRetryDuration(),
+                                                                                credentials.getMaxRetryDuration(),
+                                                                                credentials.getMaxRetryCount(),
+                                                                                credentials.isRetryOnBackendError()));
   }
 
   /**
@@ -58,22 +64,42 @@ public class SalesforceConnectionUtil {
     if (conf.get(SalesforceConstants.CONFIG_CONNECT_TIMEOUT) != null) {
       connectTimeout = Integer.parseInt(conf.get(SalesforceConstants.CONFIG_CONNECT_TIMEOUT));
     }
+    Long initialRetryDuration = conf.get(SalesforceConstants.CONFIG_INITIAL_RETRY_DURATION) != null
+      ? Long.parseLong(conf.get(SalesforceConstants.CONFIG_INITIAL_RETRY_DURATION))
+      : SalesforceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS;
+
+    Long maxRetryDuration = conf.get(SalesforceConstants.CONFIG_MAX_RETRY_DURATION) != null
+      ? Long.parseLong(conf.get(SalesforceConstants.CONFIG_MAX_RETRY_DURATION))
+      : SalesforceConstants.DEFAULT_MAX_RETRY_DURATION_SECONDS;
+
+    Integer maxRetryCount = conf.get(SalesforceConstants.CONFIG_MAX_RETRY_COUNT) != null
+      ? Integer.parseInt(conf.get(SalesforceConstants.CONFIG_MAX_RETRY_COUNT))
+      : SalesforceConstants.DEFAULT_MAX_RETRY_COUNT;
+
+    Boolean retryBackendError = conf.get(SalesforceConstants.CONFIG_RETRY_REQUIRED) != null
+      ? Boolean.parseBoolean(conf.get(SalesforceConstants.CONFIG_RETRY_REQUIRED))
+      : Boolean.TRUE;
+
     Integer readTimeout = SalesforceConstants.DEFAULT_READ_TIMEOUT_SEC * 1000;
     if (conf.get(SalesforceConstants.CONFIG_READ_TIMEOUT) != null) {
       readTimeout = Integer.parseInt(conf.get(SalesforceConstants.CONFIG_READ_TIMEOUT));
     }
     String proxyUrl = conf.get(SalesforceConstants.CONFIG_PROXY_URL);
+
     if (oAuthToken != null && instanceURL != null) {
       return AuthenticatorCredentials.fromParameters(
-              new OAuthInfo(oAuthToken, instanceURL), connectTimeout, readTimeout, proxyUrl);
+        new OAuthInfo(oAuthToken, instanceURL), connectTimeout, readTimeout, proxyUrl,
+        initialRetryDuration, maxRetryDuration, maxRetryCount, retryBackendError);
     }
 
     return AuthenticatorCredentials.fromParameters(conf.get(SalesforceConstants.CONFIG_USERNAME),
-                                        conf.get(SalesforceConstants.CONFIG_PASSWORD),
-                                        conf.get(SalesforceConstants.CONFIG_CONSUMER_KEY),
-                                        conf.get(SalesforceConstants.CONFIG_CONSUMER_SECRET),
-                                        conf.get(SalesforceConstants.CONFIG_LOGIN_URL),
-                                        connectTimeout, readTimeout, proxyUrl);
+                                                   conf.get(SalesforceConstants.CONFIG_PASSWORD),
+                                                   conf.get(SalesforceConstants.CONFIG_CONSUMER_KEY),
+                                                   conf.get(SalesforceConstants.CONFIG_CONSUMER_SECRET),
+                                                   conf.get(SalesforceConstants.CONFIG_LOGIN_URL),
+                                                   connectTimeout, readTimeout, proxyUrl,
+                                                   initialRetryDuration, maxRetryDuration, maxRetryCount,
+                                                   retryBackendError);
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -39,6 +39,10 @@ public class SalesforceConstants {
   public static final String PROPERTY_SECURITY_TOKEN = "securityToken";
   public static final String PROPERTY_LOGIN_URL = "loginUrl";
   public static final String PROPERTY_OAUTH_INFO = "oAuthInfo";
+  public static final String PROPERTY_INITIAL_RETRY_DURATION = "initialRetryDuration";
+  public static final String PROPERTY_MAX_RETRY_DURATION = "maxRetryDuration";
+  public static final String PROPERTY_MAX_RETRY_COUNT = "maxRetryCount";
+  public static final String PROPERTY_RETRY_REQUIRED = "retryOnBackendError";
 
   public static final String CONFIG_OAUTH_TOKEN = "mapred.salesforce.oauth.token";
   public static final String CONFIG_OAUTH_INSTANCE_URL = "mapred.salesforce.oauth.instance.url";
@@ -57,6 +61,10 @@ public class SalesforceConstants {
   public static final String PROPERTY_READ_TIMEOUT = "readTimeout";
   public static final String CONFIG_CONNECT_TIMEOUT = "mapred.salesforce.connectTimeout";
   public static final String CONFIG_READ_TIMEOUT = "mapred.salesforce.readTimeout";
+  public static final String CONFIG_INITIAL_RETRY_DURATION = "mapred.salesforce.initialRetryDuration";
+  public static final String CONFIG_MAX_RETRY_DURATION = "mapred.salesforce.maxRetryDuration";
+  public static final String CONFIG_MAX_RETRY_COUNT = "mapred.salesforce.maxRetryCount";
+  public static final String CONFIG_RETRY_REQUIRED = "mapred.salesforce.retryOnBackendError";
 
   public static final String PROPERTY_PROXY_URL = "proxyUrl";
   public static final String CONFIG_PROXY_URL = "mapred.salesforce.proxyUrl";
@@ -67,6 +75,11 @@ public class SalesforceConstants {
 
   public static Function<PluginConfig, Boolean> isOAuthMacroFunction = config -> config.containsMacro(
     PROPERTY_OAUTH_INFO);
+  public static final long DEFAULT_INITIAL_RETRY_DURATION_SECONDS = 5L;
+
+  public static final long DEFAULT_MAX_RETRY_DURATION_SECONDS = 80L;
+
+  public static final int DEFAULT_MAX_RETRY_COUNT = 5;
 
   // Below is the list of Objects not supported by Bulk API. Attachment, ContentVersion, Document, StaticResource,
   // SControl, EmailCapture, MailmergeTemplate contains binary fields which will cause the batch read to fail.

--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentials.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentials.java
@@ -38,17 +38,25 @@ public class AuthenticatorCredentials implements Serializable {
   private final Integer connectTimeout;
   private final Integer readTimeout;
   private final String proxyUrl;
+  private final Long initialRetryDuration;
+  private final Long maxRetryDuration;
+  private final Integer maxRetryCount;
+  private final Boolean retryOnBackendError;
 
   public AuthenticatorCredentials(@Nullable OAuthInfo oAuthInfo,
-                                   @Nullable String username,
-                                   @Nullable String password,
-                                   @Nullable String consumerKey,
-                                   @Nullable String consumerSecret,
-                                   @Nullable String loginUrl,
-                                   @Nullable GrantType grantType,
-                                   @Nullable Integer connectTimeout,
-                                   @Nullable Integer readTimeout,
-                                   @Nullable String proxyUrl) {
+                                  @Nullable String username,
+                                  @Nullable String password,
+                                  @Nullable String consumerKey,
+                                  @Nullable String consumerSecret,
+                                  @Nullable String loginUrl,
+                                  @Nullable GrantType grantType,
+                                  @Nullable Integer connectTimeout,
+                                  @Nullable Integer readTimeout,
+                                  @Nullable String proxyUrl,
+                                  @Nullable Long initialRetryDuration,
+                                  @Nullable Long maxRetryDuration,
+                                  @Nullable Integer maxRetryCount,
+                                  @Nullable Boolean retryOnBackendError) {
     this.oAuthInfo = oAuthInfo;
     this.username = username;
     this.password = password;
@@ -59,6 +67,10 @@ public class AuthenticatorCredentials implements Serializable {
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
     this.proxyUrl = proxyUrl;
+    this.retryOnBackendError = retryOnBackendError;
+    this.initialRetryDuration = initialRetryDuration;
+    this.maxRetryDuration = maxRetryDuration;
+    this.maxRetryCount = maxRetryCount;
   }
 
   @Nullable
@@ -110,6 +122,26 @@ public class AuthenticatorCredentials implements Serializable {
     return proxyUrl;
   }
 
+  @Nullable
+  public Long getInitialRetryDuration() {
+    return initialRetryDuration;
+  }
+
+  @Nullable
+  public Long getMaxRetryDuration() {
+    return maxRetryDuration;
+  }
+
+  @Nullable
+  public Integer getMaxRetryCount() {
+    return maxRetryCount;
+  }
+
+  @Nullable
+  public Boolean isRetryOnBackendError() {
+    return retryOnBackendError;
+  }
+
   /**
    * Builder for {@link AuthenticatorCredentials} with credentials for username-password OAuth flow, where
    * Salesforce OAuth {@link GrantType} is set as "password".
@@ -147,23 +179,37 @@ public class AuthenticatorCredentials implements Serializable {
    */
   public static AuthenticatorCredentials fromParameters(String username, String password,
                                                         String consumerKey, String consumerSecret, String loginUrl,
-                                                        Integer connectTimeout, Integer readTimeout, String proxyUrl) {
+                                                        Integer connectTimeout, Integer readTimeout, String proxyUrl,
+                                                        Long initialRetryDuration, Long maxRetryDuration,
+                                                        Integer maxRetryCount, Boolean retryOnBackendError) {
     AuthenticatorCredentials.Builder builder;
     if (username != null && password != null) {
       builder = AuthenticatorCredentials.getBuilder(username, password, consumerKey, consumerSecret, loginUrl);
     } else {
       builder = AuthenticatorCredentials.getBuilder(consumerKey, consumerSecret, loginUrl);
     }
-    return builder.setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).setProxyUrl(proxyUrl).build();
+    return builder.setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).setProxyUrl(proxyUrl)
+      .setInitialRetryDuration(initialRetryDuration)
+      .setMaxRetryDuration(maxRetryDuration)
+      .setMaxRetryCount(maxRetryCount)
+      .setRetryOnBackendError(retryOnBackendError)
+      .build();
   }
 
   /**
    * Create an instance of {@link AuthenticatorCredentials} from given {@link OAuthInfo} and parameters.
    */
   public static AuthenticatorCredentials fromParameters(OAuthInfo oAuthInfo,
-                                                        Integer connectTimeout, Integer readTimeout, String proxyUrl) {
+                                                        Integer connectTimeout, Integer readTimeout, String proxyUrl,
+                                                        Long initialRetryDuration, Long maxRetryDuration,
+                                                        Integer maxRetryCount, Boolean retryOnBackendError) {
     return AuthenticatorCredentials.getBuilder(oAuthInfo)
-            .setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).setProxyUrl(proxyUrl).build();
+      .setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).setProxyUrl(proxyUrl)
+      .setInitialRetryDuration(initialRetryDuration)
+      .setMaxRetryDuration(maxRetryDuration)
+      .setMaxRetryCount(maxRetryCount)
+      .setRetryOnBackendError(retryOnBackendError)
+      .build();
   }
 
   @Override
@@ -185,13 +231,18 @@ public class AuthenticatorCredentials implements Serializable {
       Objects.equals(connectTimeout, that.connectTimeout) &&
       Objects.equals(readTimeout, that.readTimeout) &&
       Objects.equals(proxyUrl, that.proxyUrl) &&
-      Objects.equals(grantType, that.grantType);
+      Objects.equals(grantType, that.grantType) &&
+      Objects.equals(retryOnBackendError, that.retryOnBackendError) &&
+      Objects.equals(initialRetryDuration, that.initialRetryDuration) &&
+      Objects.equals(maxRetryDuration, that.maxRetryDuration) &&
+      Objects.equals(maxRetryCount, that.maxRetryCount);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(username, password, consumerKey, consumerSecret, loginUrl, connectTimeout, readTimeout,
-                        proxyUrl, grantType);
+                        proxyUrl, grantType, retryOnBackendError, initialRetryDuration, maxRetryDuration,
+                        maxRetryCount);
   }
 
   /**
@@ -208,6 +259,10 @@ public class AuthenticatorCredentials implements Serializable {
     private Integer connectTimeout;
     private Integer readTimeout;
     private String proxyUrl;
+    private Long initialRetryDuration;
+    private Long maxRetryDuration;
+    private Integer maxRetryCount;
+    private Boolean retryOnBackendError;
 
     /**
      * Create an instance of {@link AuthenticatorCredentials} with credentials for username-password OAuth flow, where
@@ -256,9 +311,30 @@ public class AuthenticatorCredentials implements Serializable {
       return this;
     }
 
+    public Builder setInitialRetryDuration(Long initialRetryDuration) {
+      this.initialRetryDuration = initialRetryDuration;
+      return this;
+    }
+
+    public Builder setMaxRetryDuration(Long maxRetryDuration) {
+      this.maxRetryDuration = maxRetryDuration;
+      return this;
+    }
+
+    public Builder setMaxRetryCount(Integer maxRetryCount) {
+      this.maxRetryCount = maxRetryCount;
+      return this;
+    }
+
+    public Builder setRetryOnBackendError(Boolean retryOnBackendError) {
+      this.retryOnBackendError = retryOnBackendError;
+      return this;
+    }
+
     public AuthenticatorCredentials build() {
       return new AuthenticatorCredentials(oAuthInfo, username, password, consumerKey, consumerSecret,
-              loginUrl, grantType, connectTimeout, readTimeout, proxyUrl);
+                                          loginUrl, grantType, connectTimeout, readTimeout, proxyUrl,
+                                          initialRetryDuration, maxRetryDuration, maxRetryCount, retryOnBackendError);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
@@ -86,6 +86,26 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
   @Nullable
   private final String loginUrl;
 
+  @Name(SalesforceConstants.PROPERTY_INITIAL_RETRY_DURATION)
+  @Description("Time taken for the first retry. Default is 5 seconds.")
+  @Nullable
+  private final Long initialRetryDuration;
+
+  @Name(SalesforceConstants.PROPERTY_MAX_RETRY_DURATION)
+  @Description("Maximum time in seconds retries can take. Default is 80 seconds.")
+  @Nullable
+  private final Long maxRetryDuration;
+
+  @Name(SalesforceConstants.PROPERTY_MAX_RETRY_COUNT)
+  @Description("Maximum number of retries allowed. Default is 5.")
+  @Nullable
+  private final Integer maxRetryCount;
+
+  @Name(SalesforceConstants.PROPERTY_RETRY_REQUIRED)
+  @Description("Retry is required or not for some of the internal call failures")
+  @Nullable
+  private final Boolean retryOnBackendError;
+
   public SalesforceConnectorBaseConfig(@Nullable String consumerKey,
                                        @Nullable String consumerSecret,
                                        @Nullable String username,
@@ -94,7 +114,11 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
                                        @Nullable String securityToken,
                                        @Nullable Integer connectTimeout,
                                        @Nullable Integer readTimeout,
-                                       @Nullable String proxyUrl) {
+                                       @Nullable String proxyUrl,
+                                       @Nullable Long initialRetryDuration,
+                                       @Nullable Long maxRetryDuration,
+                                       @Nullable Integer maxRetryCount,
+                                       @Nullable Boolean retryOnBackendError) {
     this.consumerKey = consumerKey;
     this.consumerSecret = consumerSecret;
     this.username = username;
@@ -104,6 +128,10 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
     this.connectTimeout = connectTimeout;
     this.readTimeout = readTimeout;
     this.proxyUrl = proxyUrl;
+    this.initialRetryDuration = initialRetryDuration;
+    this.maxRetryDuration = maxRetryDuration;
+    this.retryOnBackendError = retryOnBackendError;
+    this.maxRetryCount = maxRetryCount;
   }
 
   @Nullable
@@ -129,6 +157,23 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
   @Nullable
   public String getLoginUrl() {
     return loginUrl;
+  }
+
+  public Long getInitialRetryDuration() {
+    return initialRetryDuration == null ? SalesforceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS :
+      initialRetryDuration;
+  }
+
+  public Long getMaxRetryDuration() {
+    return maxRetryDuration == null ? SalesforceConstants.DEFAULT_MAX_RETRY_DURATION_SECONDS : maxRetryDuration;
+  }
+
+  public Integer getMaxRetryCount() {
+    return maxRetryCount == null ? SalesforceConstants.DEFAULT_MAX_RETRY_COUNT : maxRetryCount;
+  }
+
+  public Boolean isRetryOnBackendError() {
+    return retryOnBackendError == null || retryOnBackendError;
   }
 
   @Nullable
@@ -163,7 +208,8 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
       return;
     }
     AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(
-            oAuthInfo, this.getConnectTimeout(), this.getReadTimeoutInMillis(), getProxyUrl());
+      oAuthInfo, this.getConnectTimeout(), this.getReadTimeoutInMillis(), getProxyUrl(),
+      getInitialRetryDuration(), getMaxRetryDuration(), getMaxRetryCount(), isRetryOnBackendError());
     try {
       SalesforceConnectionUtil.getPartnerConnection(credentials);
     } catch (ConnectionException e) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
@@ -87,6 +87,22 @@ public class SalesforceConnectorInfo {
     return config.getProxyUrl();
   }
 
+  public Long getInitialRetryDuration() {
+    return config.getInitialRetryDuration();
+  }
+
+  public Long getMaxRetryDuration() {
+    return config.getMaxRetryDuration();
+  }
+
+  public Integer getMaxRetryCount() {
+    return config.getMaxRetryCount();
+  }
+
+  public Boolean isRetryOnBackendError() {
+    return config.isRetryOnBackendError();
+  }
+
   public void validate(FailureCollector collector, @Nullable OAuthInfo oAuthInfo) {
     try {
       validateConnection(oAuthInfo);
@@ -102,11 +118,16 @@ public class SalesforceConnectorInfo {
     OAuthInfo oAuthInfo = getOAuthInfo();
     if (oAuthInfo != null) {
       return AuthenticatorCredentials.fromParameters(
-              oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(), config.getProxyUrl());
+        oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(), config.getProxyUrl(),
+        config.getInitialRetryDuration(), config.getMaxRetryDuration(), config.getMaxRetryCount(),
+        config.isRetryOnBackendError());
     }
     return AuthenticatorCredentials.fromParameters(config.getUsername(), config.getPassword(), config.getConsumerKey(),
                                         config.getConsumerSecret(), config.getLoginUrl(), config.getConnectTimeout(),
-                                        config.getReadTimeoutInMillis(), config.getProxyUrl());
+                                                   config.getReadTimeoutInMillis(), config.getProxyUrl(),
+                                                   config.getInitialRetryDuration(), config.getMaxRetryDuration(),
+                                                   config.getMaxRetryCount(),
+                                                   config.isRetryOnBackendError());
   }
 
   /**
@@ -141,7 +162,9 @@ public class SalesforceConnectorInfo {
       return;
     }
     AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(
-            oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(), config.getProxyUrl());
+      oAuthInfo, config.getConnectTimeout(), config.getReadTimeoutInMillis(), config.getProxyUrl(),
+      config.getInitialRetryDuration(), config.getMaxRetryDuration(), config.getMaxRetryCount(),
+      config.isRetryOnBackendError());
 
     try {
       SalesforceConnectionUtil.getPartnerConnection(credentials);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
@@ -109,7 +109,11 @@ public class SalesforceConnector implements DirectConnector {
                                                                         config.getLoginUrl(),
                                                                         config.getConnectTimeout(),
                                                                         config.getReadTimeoutInMillis(),
-                                                                        config.getProxyUrl());
+                                                                        config.getProxyUrl(),
+                                                                        config.getInitialRetryDuration(),
+                                                                        config.getMaxRetryDuration(),
+                                                                        config.getMaxRetryCount(),
+                                                                        config.isRetryOnBackendError());
     BrowseDetail.Builder browseDetailBuilder = BrowseDetail.builder();
     int count = 0;
     try {
@@ -210,7 +214,6 @@ public class SalesforceConnector implements DirectConnector {
       record = transformer.transform(schema, soapRecordToMapTransformer.transformToMap(sObjects[i], sObjectDescriptor));
       samples.add(record);
     }
-
     return samples;
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnectorConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnectorConfig.java
@@ -47,9 +47,13 @@ public class SalesforceConnectorConfig extends SalesforceConnectorBaseConfig {
                                    @Nullable Integer connectTimeout,
                                    @Nullable Integer readTimeout,
                                    @Nullable OAuthInfo oAuthInfo,
-                                   @Nullable String proxyUrl) {
+                                   @Nullable String proxyUrl,
+                                   @Nullable Long initialRetryDuration,
+                                   @Nullable Long maxRetryDuration,
+                                   @Nullable Integer maxRetryCount,
+                                   @Nullable Boolean retryOnBackendError) {
     super(consumerKey, consumerSecret, username, password, loginUrl, securityToken, connectTimeout, readTimeout,
-          proxyUrl);
+          proxyUrl, initialRetryDuration, maxRetryDuration, maxRetryCount, retryOnBackendError);
     this.oAuthInfo = oAuthInfo;
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormatProvider.java
@@ -28,7 +28,6 @@ import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
-import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,10 +57,14 @@ public class SalesforceOutputFormatProvider implements OutputFormatProvider {
       .put(SalesforceSinkConstants.CONFIG_MAX_RECORDS_PER_BATCH, config.getMaxRecordsPerBatch().toString())
       .put(SalesforceConstants.CONFIG_CONNECT_TIMEOUT, config.getConnection().getConnectTimeout().toString())
       .put(SalesforceConstants.CONFIG_READ_TIMEOUT, config.getConnection().getReadTimeout().toString())
-      .put(SalesforceSourceConstants.CONFIG_INITIAL_RETRY_DURATION, Long.toString(config.getInitialRetryDuration()))
-      .put(SalesforceSourceConstants.CONFIG_MAX_RETRY_DURATION, Long.toString(config.getMaxRetryDuration()))
-      .put(SalesforceSourceConstants.CONFIG_MAX_RETRY_COUNT, Integer.toString(config.getMaxRetryCount()))
-      .put(SalesforceSourceConstants.CONFIG_RETRY_REQUIRED, Boolean.toString(config.isRetryRequired()));
+      .put(SalesforceConstants.CONFIG_INITIAL_RETRY_DURATION,
+           Long.toString(config.getConnection().getInitialRetryDuration()))
+      .put(SalesforceConstants.CONFIG_MAX_RETRY_DURATION,
+           Long.toString(config.getConnection().getMaxRetryDuration()))
+      .put(SalesforceConstants.CONFIG_MAX_RETRY_COUNT,
+           Integer.toString(config.getConnection().getMaxRetryCount()))
+      .put(SalesforceConstants.CONFIG_RETRY_REQUIRED, Boolean.toString(config.getConnection()
+                                                                         .isRetryOnBackendError()));
 
     if (!Strings.isNullOrEmpty(config.getConnection().getProxyUrl())) {
       configBuilder.put(SalesforceConstants.CONFIG_PROXY_URL, config.getConnection().getProxyUrl());
@@ -89,8 +92,12 @@ public class SalesforceOutputFormatProvider implements OutputFormatProvider {
 
     try {
       BulkConnection bulkConnection = new BulkConnection(Authenticator.createConnectorConfig(credentials));
-      BulkConnectionRetryWrapper retryWrapper = new BulkConnectionRetryWrapper(bulkConnection, config.isRetryRequired(),
-        config.getInitialRetryDuration(), config.getMaxRetryDuration(), config.getMaxRetryCount());
+      BulkConnectionRetryWrapper retryWrapper =
+        new BulkConnectionRetryWrapper(bulkConnection,
+                                       config.getConnection().isRetryOnBackendError(),
+                                       config.getConnection().getInitialRetryDuration(),
+                                       config.getConnection().getMaxRetryDuration(),
+                                       config.getConnection().getMaxRetryCount());
       JobInfo job = SalesforceBulkUtil.createJob(retryWrapper, config.getSObject(), config.getOperationEnum(),
                                                  config.getExternalIdField(), config.getConcurrencyModeEnum(),
                                                  ContentType.ZIP_CSV);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
@@ -35,13 +35,11 @@ import io.cdap.plugin.salesforce.SObjectsDescribeResult;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
-import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorBaseConfig;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorInfo;
 import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
-import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,26 +151,6 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
   @Description("Whether to validate the field data types of the input schema as per Salesforce specific data types")
   private final Boolean datatypeValidation;
 
-  @Name(SalesforceSourceConstants.PROPERTY_INITIAL_RETRY_DURATION)
-  @Description("Time taken for the first retry. Default is 5 seconds.")
-  @Nullable
-  private Long initialRetryDuration;
-
-  @Name(SalesforceSourceConstants.PROPERTY_MAX_RETRY_DURATION)
-  @Description("Maximum time in seconds retries can take. Default is 80 seconds.")
-  @Nullable
-  private Long maxRetryDuration;
-
-  @Name(SalesforceSourceConstants.PROPERTY_MAX_RETRY_COUNT)
-  @Description("Maximum number of retries allowed. Default is 5.")
-  @Nullable
-  private Integer maxRetryCount;
-
-  @Name(SalesforceSourceConstants.PROPERTY_RETRY_REQUIRED)
-  @Description("Retry is required or not for some of the internal call failures.")
-  @Nullable
-  private Boolean retryOnBackendError;
-
   public SalesforceSinkConfig(String referenceName,
                               @Nullable String clientId,
                               @Nullable String clientSecret,
@@ -188,10 +166,16 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
                               @Nullable String securityToken,
                               @Nullable OAuthInfo oAuthInfo,
                               @Nullable String proxyUrl,
-                              @Nullable Boolean datatypeValidation) {
+                              @Nullable Boolean datatypeValidation,
+                              @Nullable Long initialRetryDuration,
+                              @Nullable Long maxRetryDuration,
+                              @Nullable Integer maxRetryCount,
+                              @Nullable Boolean retryOnBackendError) {
     super(referenceName);
     connection = new SalesforceConnectorConfig(clientId, clientSecret, username, password, loginUrl,
-                                               securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl);
+                                               securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl,
+                                               initialRetryDuration, maxRetryDuration, maxRetryCount,
+                                               retryOnBackendError);
     this.sObject = sObject;
     this.operation = operation;
     this.externalIdField = externalIdField;
@@ -289,30 +273,18 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
   }
 
   public String getOrgId(OAuthInfo oAuthInfo) throws ConnectionException {
-    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                        this.getConnection().getConnectTimeout(),
-                                                                        this.getConnection().getReadTimeout(),
-                                                                        this.connection.getProxyUrl());
+    AuthenticatorCredentials credentials =
+      AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                              this.getConnection().getConnectTimeout(),
+                                              this.getConnection().getReadTimeout(),
+                                              this.getConnection().getProxyUrl(),
+                                              this.getConnection().getInitialRetryDuration(),
+                                              this.getConnection().getMaxRetryDuration(),
+                                              this.getConnection().getMaxRetryCount(),
+                                              this.getConnection().isRetryOnBackendError());
     PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection
       (credentials);
     return partnerConnection.getUserInfo().getOrganizationId();
-  }
-
-  public boolean isRetryRequired() {
-    return retryOnBackendError == null || retryOnBackendError;
-  }
-
-  public long getInitialRetryDuration() {
-    return initialRetryDuration == null ? SalesforceSourceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS :
-        initialRetryDuration;
-  }
-
-  public long getMaxRetryDuration() {
-    return maxRetryDuration == null ? SalesforceSourceConstants.DEFULT_MAX_RETRY_DURATION_SECONDS : maxRetryDuration;
-  }
-
-  public int getMaxRetryCount() {
-    return maxRetryCount == null ? SalesforceSourceConstants.DEFAULT_MAX_RETRY_COUNT : maxRetryCount;
   }
 
   public void validate(Schema schema, FailureCollector collector, @Nullable OAuthInfo oAuthInfo) {
@@ -468,12 +440,17 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
   }
 
   private SObjectsDescribeResult getSObjectDescribeResult(FailureCollector collector, OAuthInfo oAuthInfo) {
-    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                        this.getConnection().getConnectTimeout(),
-                                                                        this.getConnection().getReadTimeout(),
-                                                                        this.getConnection().getProxyUrl());
+    AuthenticatorCredentials credentials =
+      AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                              this.getConnection().getConnectTimeout(),
+                                              this.getConnection().getReadTimeout(),
+                                              this.getConnection().getProxyUrl(),
+                                              this.getConnection().getInitialRetryDuration(),
+                                              this.getConnection().getMaxRetryDuration(),
+                                              this.getConnection().getMaxRetryCount(),
+                                              this.getConnection().isRetryOnBackendError());
     try {
-      PartnerConnection partnerConnection = new PartnerConnection(Authenticator.createConnectorConfig(credentials));
+      PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
       SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(this.getSObject(), credentials);
       return SObjectsDescribeResult.of(partnerConnection,
                                        sObjectDescriptor.getName(), sObjectDescriptor.getFeaturedSObjects());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -17,6 +17,7 @@ package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.base.Strings;
 import com.sforce.async.OperationEnum;
+import com.sforce.soap.partner.GetUserInfoResult;
 import com.sforce.soap.partner.PartnerConnection;
 import com.sforce.ws.ConnectionException;
 import io.cdap.cdap.api.annotation.Description;
@@ -93,26 +94,6 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
   @Nullable
   private String operation;
 
-  @Name(SalesforceSourceConstants.PROPERTY_INITIAL_RETRY_DURATION)
-  @Description("Time taken for the first retry. Default is 5 seconds.")
-  @Nullable
-  private Long initialRetryDuration;
-
-  @Name(SalesforceSourceConstants.PROPERTY_MAX_RETRY_DURATION)
-  @Description("Maximum time in seconds retries can take. Default is 80 seconds.")
-  @Nullable
-  private Long maxRetryDuration;
-
-  @Name(SalesforceSourceConstants.PROPERTY_MAX_RETRY_COUNT)
-  @Description("Maximum number of retries allowed. Default is 5.")
-  @Nullable
-  private Integer maxRetryCount;
-
-  @Name(SalesforceSourceConstants.PROPERTY_RETRY_REQUIRED)
-  @Description("Retry is required or not for some of the internal call failures")
-  @Nullable
-  private Boolean retryOnBackendError;
-
   @Name(ConfigUtil.NAME_USE_CONNECTION)
   @Nullable
   @Description("Whether to use an existing connection.")
@@ -151,29 +132,23 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
                                        @Nullable Long initialRetryDuration,
                                        @Nullable Long maxRetryDuration,
                                        @Nullable Integer maxRetryCount,
-                                       Boolean retryOnBackendError,
+                                       @Nullable Boolean retryOnBackendError,
                                        @Nullable String proxyUrl) {
     super(referenceName);
     this.connection = new SalesforceConnectorConfig(consumerKey, consumerSecret, username, password, loginUrl,
-                                                    securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl);
+                                                    securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl,
+                                                    initialRetryDuration, maxRetryDuration, maxRetryCount,
+                                                    retryOnBackendError);
     this.datetimeAfter = datetimeAfter;
     this.datetimeBefore = datetimeBefore;
     this.duration = duration;
     this.offset = offset;
     this.operation = operation;
-    this.initialRetryDuration = initialRetryDuration;
-    this.maxRetryDuration = maxRetryDuration;
-    this.retryOnBackendError = retryOnBackendError;
-    this.maxRetryCount = maxRetryCount;
   }
 
 
   public Map<ChronoUnit, Integer> getDuration() {
     return extractRangeValue(SalesforceSourceConstants.PROPERTY_DURATION, duration);
-  }
-
-  public Boolean isRetryRequired() {
-    return retryOnBackendError == null || retryOnBackendError;
   }
 
   public Map<ChronoUnit, Integer> getOffset() {
@@ -214,26 +189,22 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
   }
 
   public String getOrgId(OAuthInfo oAuthInfo) throws ConnectionException {
-    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                        this.getConnection().getConnectTimeout(),
-                                                                        this.getConnection().getReadTimeout(),
-                                                                        this.connection.getProxyUrl());
+    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(
+            oAuthInfo,
+            this.getConnection().getConnectTimeout(),
+            this.getConnection().getReadTimeout(),
+            this.connection.getProxyUrl(),
+            this.connection.getInitialRetryDuration(),
+            this.connection.getMaxRetryDuration(),
+            this.connection.getMaxRetryCount(),
+            this.connection.isRetryOnBackendError()
+    );
+
     PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
-    return partnerConnection.getUserInfo().getOrganizationId();
+    GetUserInfoResult userInfo = partnerConnection.getUserInfo();
+    return userInfo.getOrganizationId();
   }
 
-  public Long getInitialRetryDuration() {
-    return initialRetryDuration == null ? SalesforceSourceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS :
-      initialRetryDuration;
-  }
-
-  public Long getMaxRetryDuration() {
-    return maxRetryDuration == null ? SalesforceSourceConstants.DEFULT_MAX_RETRY_DURATION_SECONDS : maxRetryDuration;
-  }
-
-  public Integer getMaxRetryCount() {
-    return maxRetryCount == null ? SalesforceSourceConstants.DEFAULT_MAX_RETRY_COUNT : maxRetryCount;
-  }
 
   public void validateFilters(FailureCollector collector) {
     try {
@@ -277,10 +248,15 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
    */
   protected String getSObjectQuery(String sObjectName, Schema schema, long logicalStartTime, OAuthInfo oAuthInfo) {
     try {
-      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                          this.getConnection().getConnectTimeout(),
-                                                                          this.getConnection().getReadTimeout(),
-                                                                          this.connection.getProxyUrl());
+      AuthenticatorCredentials credentials =
+        AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                                this.getConnection().getConnectTimeout(),
+                                                this.getConnection().getReadTimeout(),
+                                                this.connection.getProxyUrl(),
+                                                this.connection.getInitialRetryDuration(),
+                                                this.connection.getMaxRetryDuration(),
+                                                this.connection.getMaxRetryCount(),
+                                                this.connection.isRetryOnBackendError());
       SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName,
                                                                        credentials,
                                                                        SalesforceSchemaUtil.COMPOUND_FIELDS);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchMultiSource.java
@@ -104,13 +104,15 @@ public class SalesforceBatchMultiSource extends BatchSource<Schema, Map<String, 
     String sObjectNameField = config.getSObjectNameField();
     authenticatorCredentials = config.getConnection().getAuthenticatorCredentials();
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
-    BulkConnectionRetryWrapper bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection,
-      config.isRetryRequired(), config.getInitialRetryDuration(), config.getMaxRetryDuration(),
-      config.getMaxRetryCount());
+    BulkConnectionRetryWrapper bulkConnectionRetryWrapper =
+      new BulkConnectionRetryWrapper(bulkConnection,
+                                     config.getConnection().isRetryOnBackendError(),
+                                     config.getConnection().getInitialRetryDuration(),
+                                     config.getConnection().getMaxRetryDuration(),
+                                     config.getConnection().getMaxRetryCount());
     List<SalesforceSplit> querySplits = queries.parallelStream()
-      .map(query -> SalesforceSplitUtil.getQuerySplits(query, bulkConnectionRetryWrapper, false, config.getOperation(),
-                                                       config.getInitialRetryDuration(), config.getMaxRetryDuration(),
-                                                       config.getMaxRetryCount(), config.isRetryRequired()))
+      .map(query -> SalesforceSplitUtil.getQuerySplits(query, bulkConnectionRetryWrapper, false,
+                                                       config.getOperation()))
       .flatMap(Collection::stream).collect(Collectors.toList());
     // store the jobIds so be used in onRunFinish() to close the connections
     querySplits.parallelStream().forEach(salesforceSplit -> jobIds.add(salesforceSplit.getJobId()));

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -166,13 +166,13 @@ public class SalesforceBatchSource extends
       bulkConnection.addHeader(SalesforceSourceConstants.HEADER_ENABLE_PK_CHUNK,
           String.join(";", chunkHeaderValues));
     }
-    BulkConnectionRetryWrapper bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection,
-      config.isRetryRequired(), config.getInitialRetryDuration(), config.getMaxRetryDuration(),
-      config.getMaxRetryCount());
-    List<SalesforceSplit> querySplits = SalesforceSplitUtil.getQuerySplits(query, bulkConnectionRetryWrapper,
-        enablePKChunk, config.getOperation(), config.getInitialRetryDuration(), config.getMaxRetryDuration(),
-          config.getMaxRetryCount(), config.isRetryRequired());
-    return querySplits;
+    BulkConnectionRetryWrapper bulkConnectionRetryWrapper =
+      new BulkConnectionRetryWrapper(bulkConnection,
+                                     config.getConnection().isRetryOnBackendError(),
+                                     config.getConnection().getInitialRetryDuration(),
+                                     config.getConnection().getMaxRetryDuration(),
+                                     config.getConnection().getMaxRetryCount());
+    return SalesforceSplitUtil.getQuerySplits(query, bulkConnectionRetryWrapper, enablePKChunk, config.getOperation());
   }
 
   @Override
@@ -216,10 +216,15 @@ public class SalesforceBatchSource extends
     String query = config.getQuery(System.currentTimeMillis(), oAuthInfo);
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     try {
-      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                          config.getConnection().getConnectTimeout(),
-                                                                          config.getConnection().getReadTimeout(),
-                                                                          config.getConnection().getProxyUrl());
+      AuthenticatorCredentials credentials =
+        AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                                config.getConnection().getConnectTimeout(),
+                                                config.getConnection().getReadTimeout(),
+                                                config.getConnection().getProxyUrl(),
+                                                config.getConnection().getInitialRetryDuration(),
+                                                config.getConnection().getMaxRetryDuration(),
+                                                config.getConnection().getMaxRetryCount(),
+                                                config.getConnection().isRetryOnBackendError());
       return SalesforceSchemaUtil.getSchema(credentials, sObjectDescriptor, setAllFieldsNullable);
     } catch (ConnectionException e) {
       String errorMessage = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReader.java
@@ -16,25 +16,18 @@
 package io.cdap.plugin.salesforce.plugin.source.batch;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.sforce.async.AsyncApiException;
-import com.sforce.async.AsyncExceptionCode;
 import com.sforce.async.BatchInfo;
 import com.sforce.async.BatchStateEnum;
 import com.sforce.async.BulkConnection;
-import dev.failsafe.Failsafe;
-import dev.failsafe.FailsafeException;
-import dev.failsafe.TimeoutExceededException;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.salesforce.BulkAPIBatchException;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
+import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
-import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
-import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
-
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
@@ -51,7 +44,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * RecordReader implementation, which reads a single Salesforce batch from bulk job
@@ -60,16 +52,7 @@ import java.util.Set;
 public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String, ?>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SalesforceBulkRecordReader.class);
-  public static final Set<AsyncExceptionCode> RETRY_ON_REASON = ImmutableSet.of(AsyncExceptionCode.Unknown,
-                                                                                AsyncExceptionCode.InternalServerError,
-                                                                                AsyncExceptionCode.ClientInputError,
-                                                                                AsyncExceptionCode.Timeout);
-  private static Long initialRetryDuration;
-  private static Long maxRetryDuration;
-  private static Integer maxRetryCount;
-  private Boolean isRetryRequired;
   private final Schema schema;
-
   private CSVParser csvParser;
   private Iterator<CSVRecord> parserIterator;
   private Map<String, ?> value;
@@ -92,12 +75,11 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     this.jobId = jobId;
     this.batchId = batchId;
     this.resultIds = resultIds;
-    initialRetryDuration = SalesforceSourceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS;
-    maxRetryDuration = SalesforceSourceConstants.DEFULT_MAX_RETRY_DURATION_SECONDS;
-    maxRetryCount = SalesforceSourceConstants.DEFAULT_MAX_RETRY_COUNT;
-    isRetryRequired = true;
-    bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection, isRetryRequired, initialRetryDuration,
-        maxRetryDuration, maxRetryCount);
+    bulkConnectionRetryWrapper =
+      new BulkConnectionRetryWrapper(bulkConnection, true,
+                                     SalesforceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS,
+                                     SalesforceConstants.DEFAULT_MAX_RETRY_DURATION_SECONDS,
+                                     SalesforceConstants.DEFAULT_MAX_RETRY_COUNT);
   }
 
   /**
@@ -112,13 +94,6 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
   public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
     throws IOException, InterruptedException {
     Configuration conf = taskAttemptContext.getConfiguration();
-    initialRetryDuration = Long.valueOf(conf.get(SalesforceSourceConstants.CONFIG_INITIAL_RETRY_DURATION,
-      String.valueOf((SalesforceSourceConstants.DEFAULT_INITIAL_RETRY_DURATION_SECONDS))));
-    maxRetryDuration = Long.valueOf(conf.get(SalesforceSourceConstants.CONFIG_MAX_RETRY_DURATION,
-      String.valueOf(SalesforceSourceConstants.DEFULT_MAX_RETRY_DURATION_SECONDS)));
-    maxRetryCount = Integer.valueOf(conf.get(SalesforceSourceConstants.CONFIG_MAX_RETRY_COUNT,
-      String.valueOf(SalesforceSourceConstants.DEFAULT_MAX_RETRY_COUNT)));
-    isRetryRequired = Boolean.valueOf(conf.get(SalesforceSourceConstants.CONFIG_RETRY_REQUIRED, String.valueOf(true)));
     AuthenticatorCredentials credentials = SalesforceConnectionUtil.getAuthenticatorCredentials(conf);
     initialize(inputSplit, credentials);
   }
@@ -129,15 +104,16 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
     jobId = salesforceSplit.getJobId();
     batchId = salesforceSplit.getBatchId();
     LOG.debug("Executing Salesforce Batch Id: '{}' for Job Id: '{}'", batchId, jobId);
-
     try {
       bulkConnection = new BulkConnection(Authenticator.createConnectorConfig(credentials));
-      bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection, isRetryRequired, initialRetryDuration,
-        maxRetryDuration, maxRetryCount);
-      resultIds = waitForBatchResults(bulkConnection);
+      bulkConnectionRetryWrapper = new BulkConnectionRetryWrapper(bulkConnection, credentials.isRetryOnBackendError(),
+                                                                  credentials.getInitialRetryDuration(),
+                                                                  credentials.getMaxRetryDuration(),
+                                                                  credentials.getMaxRetryCount());
+      resultIds = waitForBatchResults(bulkConnectionRetryWrapper);
       LOG.debug("Batch {} returned {} results", batchId, resultIds.length);
       setupParser();
-    } catch (AsyncApiException | SalesforceQueryExecutionException e) {
+    } catch (AsyncApiException e) {
       throw new RuntimeException(
         String.format("Failed to wait for the result of a batch: %s", e.getMessage()),
         e);
@@ -205,7 +181,7 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
   }
 
   @VisibleForTesting
-  void setupParser() throws IOException, AsyncApiException, InterruptedException {
+  void setupParser() throws IOException, AsyncApiException {
     if (resultIdIndex >= resultIds.length) {
       throw new IllegalArgumentException(String.format("Invalid resultIdIndex %d, should be less than %d",
         resultIdIndex, resultIds.length));
@@ -224,29 +200,8 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
       }
       parserIterator = csvParser.iterator();
       resultIdIndex++;
-    } catch (TimeoutExceededException e) {
-      throw new AsyncApiException("Exhausted retries trying to get query result stream", AsyncExceptionCode.Timeout);
-    } catch (FailsafeException e) {
-      if (e.getCause() instanceof InterruptedException) {
-        throw (InterruptedException) e.getCause();
-      }
-      if (e.getCause() instanceof AsyncApiException) {
-        throw (AsyncApiException) e.getCause();
-      }
+    } catch (AsyncApiException e) {
       throw e;
-    }
-  }
-
-  public InputStream getQueryResultStream(BulkConnection bulkConnection)
-    throws SalesforceQueryExecutionException, AsyncApiException {
-    try {
-      return bulkConnection.getQueryResultStream(jobId, batchId, resultIds[resultIdIndex]);
-    } catch (AsyncApiException exception) {
-      LOG.warn("The bulk query job {} failed.", jobId);
-      if (RETRY_ON_REASON.contains(exception.getExceptionCode())) {
-        throw new SalesforceQueryExecutionException(exception);
-      }
-      throw exception;
     }
   }
 
@@ -258,8 +213,8 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
    * @throws AsyncApiException    if there is an issue creating the job
    * @throws InterruptedException sleep interrupted
    */
-  private String[] waitForBatchResults(BulkConnection bulkConnection)
-    throws AsyncApiException, InterruptedException, SalesforceQueryExecutionException {
+  private String[] waitForBatchResults(BulkConnectionRetryWrapper bulkConnection)
+    throws AsyncApiException, InterruptedException {
     BatchInfo info = null;
     for (int i = 0; i < SalesforceSourceConstants.GET_BATCH_RESULTS_TRIES; i++) {
       try {
@@ -273,26 +228,7 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
       }
 
       if (info.getState() == BatchStateEnum.Completed) {
-        try {
-          if (isRetryRequired) {
-            return Failsafe.with(
-                SalesforceSplitUtil.getRetryPolicy(initialRetryDuration, maxRetryDuration, maxRetryCount))
-              .get(() -> getQueryResultList(bulkConnection));
-          } else {
-            return bulkConnection.getQueryResultList(jobId, batchId).getResult();
-          }
-
-        } catch (TimeoutExceededException e) {
-          throw new AsyncApiException("Exhausted retries trying to get query result list", AsyncExceptionCode.Timeout);
-        } catch (FailsafeException e) {
-          if (e.getCause() instanceof InterruptedException) {
-            throw (InterruptedException) e.getCause();
-          }
-          if (e.getCause() instanceof AsyncApiException) {
-            throw (AsyncApiException) e.getCause();
-          }
-          throw e;
-        }
+        return bulkConnection.getQueryResultList(jobId, batchId);
       } else if (info.getState() == BatchStateEnum.Failed) {
         throw new BulkAPIBatchException("Batch failed", info);
       } else {
@@ -301,18 +237,5 @@ public class SalesforceBulkRecordReader extends RecordReader<Schema, Map<String,
       }
     }
     throw new BulkAPIBatchException("Timeout waiting for batch results", info);
-  }
-
-  private String[] getQueryResultList(BulkConnection bulkConnection)
-    throws SalesforceQueryExecutionException, AsyncApiException {
-    try {
-      return bulkConnection.getQueryResultList(jobId, batchId).getResult();
-    } catch (AsyncApiException exception) {
-      LOG.warn("The bulk query job {} failed.", jobId);
-      if (RETRY_ON_REASON.contains(exception.getExceptionCode())) {
-        throw new SalesforceQueryExecutionException(exception);
-      }
-      throw exception;
-    }
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
@@ -47,10 +47,11 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
     configBuilder.put(SalesforceSourceConstants.CONFIG_QUERY_SPLITS, GSON.toJson(querySplits))
       .put(SalesforceConstants.CONFIG_CONNECT_TIMEOUT, config.getConnection().getConnectTimeout().toString())
       .put(SalesforceConstants.CONFIG_READ_TIMEOUT, config.getConnection().getReadTimeout().toString())
-      .put(SalesforceSourceConstants.CONFIG_INITIAL_RETRY_DURATION, config.getInitialRetryDuration().toString())
-      .put(SalesforceSourceConstants.CONFIG_MAX_RETRY_DURATION, config.getMaxRetryDuration().toString())
-      .put(SalesforceSourceConstants.CONFIG_MAX_RETRY_COUNT, config.getMaxRetryCount().toString())
-      .put(SalesforceSourceConstants.CONFIG_RETRY_REQUIRED, config.isRetryRequired().toString());
+      .put(SalesforceConstants.CONFIG_INITIAL_RETRY_DURATION,
+           config.getConnection().getInitialRetryDuration().toString())
+      .put(SalesforceConstants.CONFIG_MAX_RETRY_DURATION, config.getConnection().getMaxRetryDuration().toString())
+      .put(SalesforceConstants.CONFIG_MAX_RETRY_COUNT, config.getConnection().getMaxRetryCount().toString())
+      .put(SalesforceConstants.CONFIG_RETRY_REQUIRED, config.getConnection().isRetryOnBackendError().toString());
 
     if (!Strings.isNullOrEmpty(config.getConnection().getProxyUrl())) {
       configBuilder.put(SalesforceConstants.CONFIG_PROXY_URL, config.getConnection().getProxyUrl());

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
@@ -176,10 +176,15 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
     }
     DescribeGlobalResult describeGlobalResult;
     try {
-      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                          getConnection().getConnectTimeout(),
-                                                                          this.getConnection().getReadTimeout(),
-                                                                          this.getConnection().getProxyUrl());
+      AuthenticatorCredentials credentials =
+        AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                                getConnection().getConnectTimeout(),
+                                                this.getConnection().getReadTimeout(),
+                                                this.getConnection().getProxyUrl(),
+                                                this.getConnection().getInitialRetryDuration(),
+                                                this.getConnection().getMaxRetryDuration(),
+                                                this.getConnection().getMaxRetryCount(),
+                                                this.getConnection().isRetryOnBackendError());
       PartnerConnection partnerConnection =
         SalesforceConnectionUtil.getPartnerConnection(credentials);
       describeGlobalResult = partnerConnection.describeGlobal();

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -30,7 +30,6 @@ import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
-import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.parser.SOQLParsingException;
 import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
@@ -226,10 +225,15 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   private void validateCompoundFields(String sObjectName, List<String> fieldNames, FailureCollector collector,
                                       OAuthInfo oAuthInfo) {
     try {
-      AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                          this.getConnection().getConnectTimeout(),
-                                                                          this.getConnection().getReadTimeout(),
-                                                                          this.getConnection().getProxyUrl());
+      AuthenticatorCredentials credentials =
+        AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                                this.getConnection().getConnectTimeout(),
+                                                this.getConnection().getReadTimeout(),
+                                                this.getConnection().getProxyUrl(),
+                                                this.getConnection().getInitialRetryDuration(),
+                                                this.getConnection().getMaxRetryDuration(),
+                                                this.getConnection().getMaxRetryCount(),
+                                                this.getConnection().isRetryOnBackendError());
       SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromName(sObjectName, credentials);
       List<String> compoundFieldNames = sObjectDescriptor.getFields().stream()
         .filter(fieldDescriptor -> fieldNames.contains(fieldDescriptor.getName()))
@@ -332,12 +336,17 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
   }
 
   private boolean isCustomObject(String sObjectName, FailureCollector collector, OAuthInfo oAuthInfo) {
-    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                        this.getConnection().getConnectTimeout(),
-                                                                        this.getConnection().getReadTimeout(),
-                                                                        this.getConnection().getProxyUrl());
+    AuthenticatorCredentials credentials =
+      AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                              this.getConnection().getConnectTimeout(),
+                                              this.getConnection().getReadTimeout(),
+                                              this.getConnection().getProxyUrl(),
+                                              this.getConnection().getInitialRetryDuration(),
+                                              this.getConnection().getMaxRetryDuration(),
+                                              this.getConnection().getMaxRetryCount(),
+                                              this.getConnection().isRetryOnBackendError());
     try {
-      PartnerConnection partnerConnection = new PartnerConnection(Authenticator.createConnectorConfig(credentials));
+      PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
       return SObjectsDescribeResult.isCustomObject(partnerConnection, sObjectName);
     } catch (ConnectionException e) {
       String message = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReader.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceWideRecordReader.java
@@ -37,7 +37,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * RecordReader implementation for wide SOQL queries. Reads a single Salesforce batch of SObject Id's from bulk job

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/BulkConnectionRetryWrapper.java
@@ -15,7 +15,9 @@
  */
 package io.cdap.plugin.salesforce.plugin.source.batch.util;
 
+import com.google.common.collect.ImmutableSet;
 import com.sforce.async.AsyncApiException;
+import com.sforce.async.AsyncExceptionCode;
 import com.sforce.async.BatchInfo;
 import com.sforce.async.BatchInfoList;
 import com.sforce.async.BulkConnection;
@@ -24,185 +26,100 @@ import com.sforce.ws.ConnectorConfig;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
-import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBulkRecordReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * BulkConnectionRetryWrapper class to retry all the salesforce api calls in case of failure.
  */
 public class BulkConnectionRetryWrapper {
-
+  public static final Set<AsyncExceptionCode> RETRY_ON_REASON = ImmutableSet.of(AsyncExceptionCode.Unknown,
+                                                                                AsyncExceptionCode.InternalServerError,
+                                                                                AsyncExceptionCode.ClientInputError,
+                                                                                AsyncExceptionCode.Timeout);
   private final BulkConnection bulkConnection;
-  private final RetryPolicy retryPolicy;
+  private final RetryPolicy<Object> retryPolicy;
   private static final Logger LOG = LoggerFactory.getLogger(BulkConnectionRetryWrapper.class);
-  private final boolean retryOnBackendError;
-  private final long maxRetryDuration;
-  private final int maxRetryCount;
-  private final long initialRetryDuration;
 
-  public BulkConnectionRetryWrapper(BulkConnection bulkConnection, boolean isRetryRequired,
+  public BulkConnectionRetryWrapper(BulkConnection bulkConnection, boolean retryOnBackendError,
                                     long initialRetryDuration, long maxRetryDuration, int maxRetryCount) {
     this.bulkConnection = bulkConnection;
-    this.retryOnBackendError = isRetryRequired;
-    this.initialRetryDuration = initialRetryDuration;
-    this.maxRetryDuration = maxRetryDuration;
-    this.maxRetryCount = maxRetryCount;
-    this.retryPolicy = SalesforceSplitUtil.getRetryPolicy(initialRetryDuration, maxRetryDuration, maxRetryCount);
+    this.retryPolicy = SalesforceSplitUtil.getRetryPolicy(initialRetryDuration, maxRetryDuration, maxRetryCount,
+                                                          retryOnBackendError);
   }
 
   public JobInfo createJob(JobInfo jobInfo) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      return bulkConnection.createJob(jobInfo);
-    }
-    Object resultJobInfo = Failsafe.with(retryPolicy).onFailure(event -> LOG.info("Failed while creating job."))
-        .get(() -> {
-          try {
-            return bulkConnection.createJob(jobInfo);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (JobInfo) resultJobInfo;
+    return executeWithRetry(() -> bulkConnection.createJob(jobInfo), "Failed while creating job.");
   }
 
   public JobInfo getJobStatus(String jobId) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      return bulkConnection.getJobStatus(jobId);
-    }
-    Object resultJobInfo = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting job status."))
-        .get(() -> {
-          try {
-            return bulkConnection.getJobStatus(jobId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (JobInfo) resultJobInfo;
-  }
-
-  public void updateJob(JobInfo jobInfo) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      bulkConnection.updateJob(jobInfo);
-      return;
-    }
-    Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while updating job."))
-        .get(() -> {
-          try {
-            return bulkConnection.updateJob(jobInfo);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
+    return executeWithRetry(() -> bulkConnection.getJobStatus(jobId), "Failed while getting job status.");
   }
 
   public BatchInfoList getBatchInfoList(String jobId) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      return bulkConnection.getBatchInfoList(jobId);
-    }
-    Object batchInfoList = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting batch info list."))
-        .get(() -> {
-          try {
-            return bulkConnection.getBatchInfoList(jobId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (BatchInfoList) batchInfoList;
+    return executeWithRetry(() -> bulkConnection.getBatchInfoList(jobId), "Failed while getting batch info list.");
   }
 
   public BatchInfo getBatchInfo(String jobId, String batchId) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      return bulkConnection.getBatchInfo(jobId, batchId);
-    }
-    Object batchInfo = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting batch status."))
-        .get(() -> {
-          try {
-            return bulkConnection.getBatchInfo(jobId, batchId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (BatchInfo) batchInfo;
+    return executeWithRetry(() -> bulkConnection.getBatchInfo(jobId, batchId), "Failed while getting batch status.");
   }
 
   public InputStream getBatchResultStream(String jobId, String batchId) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      return bulkConnection.getBatchResultStream(jobId, batchId);
-    }
-    Object inputStream = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting batch result stream."))
-        .get(() -> {
-          try {
-            return bulkConnection.getBatchResultStream(jobId, batchId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (InputStream) inputStream;
+    return executeWithRetry(() -> bulkConnection.getBatchResultStream(jobId, batchId),
+                            "Failed while getting batch result stream.");
   }
 
   public InputStream getQueryResultStream(String jobId, String batchId, String resultId) throws AsyncApiException {
-    if (!retryOnBackendError) {
-      return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
-    }
-    Object inputStream = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while getting query result stream."))
-        .get(() -> {
-          try {
-            return bulkConnection.getQueryResultStream(jobId, batchId, resultId);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (InputStream) inputStream;
+    return executeWithRetry(() -> bulkConnection.getQueryResultStream(jobId, batchId, resultId),
+                            "Failed while getting query result stream.");
   }
 
   public BatchInfo createBatchFromStream(String query, JobInfo job) throws AsyncApiException,
     SalesforceQueryExecutionException, IOException {
-    if (!retryOnBackendError) {
-      return createBatchFromStreamI(query, job);
-    }
-    Object batchInfo = Failsafe.with(retryPolicy)
-        .onFailure(event -> LOG.info("Failed while creating batch from stream."))
-        .get(() -> {
-          try {
-            return createBatchFromStreamI(query, job);
-          } catch (AsyncApiException e) {
-            throw new SalesforceQueryExecutionException(e);
-          }
-        });
-    return (BatchInfo) batchInfo;
-  }
-
-  private BatchInfo createBatchFromStreamI(String query, JobInfo job) throws
-    SalesforceQueryExecutionException, IOException, AsyncApiException {
-    BatchInfo batchInfo = null;
     try (ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes())) {
-      batchInfo = bulkConnection.createBatchFromStream(job, bout);
-    } catch (AsyncApiException exception) {
-      LOG.warn("The bulk query job {} failed. Job State: {}.", job.getId(), job.getState());
-      if (SalesforceBulkRecordReader.RETRY_ON_REASON.contains(exception.getExceptionCode())) {
-        throw new SalesforceQueryExecutionException(exception);
-      }
-      throw exception;
+      return executeWithRetry(() -> bulkConnection.createBatchFromStream(job, bout),
+                              String.format("The bulk query job %s failed. Job State: %s.",
+                                            job.getId(), job.getState()));
     }
-    return batchInfo;
   }
 
   public ConnectorConfig getConfig() {
     return bulkConnection.getConfig();
   }
-  
-  public BulkConnection getBukConnection() {
-    return bulkConnection;
+
+  public String[] getQueryResultList(String jobId, String batchId)
+    throws AsyncApiException {
+    return executeWithRetry(() -> bulkConnection.getQueryResultList(jobId, batchId).getResult(),
+                            String.format("The bulk query job %s failed.", jobId));
+  }
+
+  private <T> T executeWithRetry(Callable<T> operation, String errorContext) throws AsyncApiException {
+    try {
+      return Failsafe.with(retryPolicy).get(() -> {
+        try {
+          T result = operation.call();
+          if (result == null) {
+            throw new IllegalArgumentException(errorContext);
+          }
+          return result;
+        } catch (AsyncApiException e) {
+          if (BulkConnectionRetryWrapper.RETRY_ON_REASON.contains(e.getExceptionCode())) {
+            throw new SalesforceQueryExecutionException(e);
+          }
+          throw e;
+        }
+      });
+    } catch (FailsafeException ex) {
+      if (ex.getCause() instanceof AsyncApiException) {
+        throw (AsyncApiException) ex.getCause();
+      }
+      throw ex;
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSourceConstants.java
@@ -32,11 +32,6 @@ public class SalesforceSourceConstants {
   public static final String PROPERTY_QUERY = "query";
   public static final String PROPERTY_SOBJECT_NAME = "sObjectName";
   public static final String PROPERTY_OPERATION = "operation";
-  public static final String PROPERTY_INITIAL_RETRY_DURATION = "initialRetryDuration";
-  public static final String PROPERTY_MAX_RETRY_DURATION = "maxRetryDuration";
-  public static final String PROPERTY_MAX_RETRY_COUNT = "maxRetryCount";
-  public static final String PROPERTY_RETRY_REQUIRED = "retryOnBackendError";
-
   public static final String PROPERTY_PK_CHUNK_ENABLE_NAME = "enablePKChunk";
   public static final String PROPERTY_CHUNK_SIZE_NAME = "chunkSize";
   public static final String PROPERTY_PARENT_NAME = "parent";
@@ -53,11 +48,6 @@ public class SalesforceSourceConstants {
   public static final String HEADER_PK_CHUNK_PARENT = "parent=%s";
 
   public static final String CONFIG_SOBJECT_NAME_FIELD = "mapred.salesforce.input.sObjectNameField";
-  public static final String CONFIG_INITIAL_RETRY_DURATION = "mapred.salesforce.initialRetryDuration";
-  public static final String CONFIG_MAX_RETRY_DURATION = "mapred.salesforce.maxRetryDuration";
-  public static final String CONFIG_MAX_RETRY_COUNT = "mapred.salesforce.maxRetryCount";
-  public static final String CONFIG_RETRY_REQUIRED = "mapred.salesforce.retryOnBackendError";
-
   public static final int WIDE_QUERY_MAX_BATCH_COUNT = 2000;
   public static final int RETRIEVE_MAX_BATCH_COUNT = 2000;
   // https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/
@@ -165,11 +155,5 @@ public class SalesforceSourceConstants {
   public static final long GET_BATCH_WAIT_TIME_SECONDS_SERIAL_MODE = 600000;
 
   public static final long MAX_RETRIES_ON_API_FAILURE = 10;
-
-  public static final long DEFAULT_INITIAL_RETRY_DURATION_SECONDS = 5L;
-
-  public static final long DEFULT_MAX_RETRY_DURATION_SECONDS = 80L;
-
-  public static final int DEFAULT_MAX_RETRY_COUNT = 5;
 
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
@@ -25,7 +25,6 @@ import com.sforce.async.ContentType;
 import com.sforce.async.JobInfo;
 import com.sforce.async.JobStateEnum;
 import com.sforce.async.OperationEnum;
-import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
 import dev.failsafe.TimeoutExceededException;
@@ -36,12 +35,10 @@ import io.cdap.plugin.salesforce.SalesforceBulkUtil;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
-import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceBulkRecordReader;
 import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceSplit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -49,6 +46,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 
 /**
  * Utility class which provides methods to generate Salesforce splits for a query.
@@ -66,11 +64,8 @@ public final class SalesforceSplitUtil {
    * @return list of salesforce splits
    */
   public static List<SalesforceSplit> getQuerySplits(String query, BulkConnectionRetryWrapper bulkConnection,
-                                                     boolean enablePKChunk, String operation,
-                                                     Long initialRetryDuration, Long maxRetryDuration,
-                                                     Integer maxRetryCount, Boolean retryOnBackendError) {
-    return Stream.of(getBatches(query, bulkConnection, enablePKChunk, operation, initialRetryDuration, maxRetryDuration,
-                                maxRetryCount, retryOnBackendError))
+                                                     boolean enablePKChunk, String operation) {
+    return Stream.of(getBatches(query, bulkConnection, enablePKChunk, operation))
       .map(batch -> new SalesforceSplit(batch.getJobId(), batch.getId(), query))
       .collect(Collectors.toList());
   }
@@ -86,16 +81,13 @@ public final class SalesforceSplitUtil {
    * @return array of batch info
    */
   private static BatchInfo[] getBatches(String query, BulkConnectionRetryWrapper bulkConnection,
-                                        boolean enablePKChunk, String operation,
-                                        Long initialRetryDuration, Long maxRetryDuration,
-                                        Integer maxRetryCount, Boolean retryOnBackendError) {
+                                        boolean enablePKChunk, String operation) {
     try {
       if (!SalesforceQueryUtil.isQueryUnderLengthLimit(query)) {
         LOG.debug("Wide object query detected. Query length '{}'", query.length());
         query = SalesforceQueryUtil.createSObjectIdQuery(query);
       }
-      BatchInfo[] batches = runBulkQuery(bulkConnection, query, enablePKChunk, operation, initialRetryDuration,
-                                         maxRetryDuration, maxRetryCount, retryOnBackendError);
+      BatchInfo[] batches = runBulkQuery(bulkConnection, query, enablePKChunk, operation);
       LOG.debug("Number of batches received from Salesforce: '{}'", batches.length);
       return batches;
     } catch (AsyncApiException | IOException | InterruptedException e) {
@@ -115,14 +107,12 @@ public final class SalesforceSplitUtil {
    * @throws IOException       failed to close the query
    */
   private static BatchInfo[] runBulkQuery(BulkConnectionRetryWrapper bulkConnection, String query,
-                                          boolean enablePKChunk, String operation,
-                                          Long initialRetryDuration, Long maxRetryDuration,
-                                          Integer maxRetryCount, Boolean retryOnBackendError)
+                                          boolean enablePKChunk, String operation)
     throws AsyncApiException, IOException, InterruptedException {
 
     SObjectDescriptor sObjectDescriptor = SObjectDescriptor.fromQuery(query);
     JobInfo job = SalesforceBulkUtil.createJob(bulkConnection, sObjectDescriptor.getName(), getOperationEnum(operation),
-      null, ConcurrencyMode.Parallel, ContentType.CSV);
+                                               null, ConcurrencyMode.Parallel, ContentType.CSV);
     BatchInfo batchInfo;
     try {
       batchInfo = bulkConnection.createBatchFromStream(query, job);
@@ -244,19 +234,22 @@ public final class SalesforceSplitUtil {
   }
 
   public static RetryPolicy<Object> getRetryPolicy(Long initialRetryDuration, Long maxRetryDuration,
-                                                    Integer maxRetryCount) {
+                                                   Integer maxRetryCount, Boolean retryOnBackendError) {
     // Exponential backoff with initial retry of 5 seconds and max retry of 80 seconds.
-    return RetryPolicy.builder()
-      .handle(SalesforceQueryExecutionException.class)
-      .withBackoff(Duration.ofSeconds(initialRetryDuration), Duration.ofSeconds(maxRetryDuration), 2)
-      .withMaxRetries(maxRetryCount)
-      .onRetry(event -> {
-        Throwable t = event.getLastException();
-        LOG.warn("Attempt #{} failed while executing job with error: {}", event.getAttemptCount(), t.getMessage(), t);
-        LOG.debug("Retrying Salesforce Bulk Query. Retry count: {}", event.getAttemptCount());
-      })
-      .onSuccess(event -> LOG.debug("Salesforce Bulk Query executed successfully."))
-      .onRetriesExceeded(event -> LOG.error("Retry limit reached for Salesforce Bulk Query."))
-      .build();
+    if (retryOnBackendError) {
+      return RetryPolicy.builder()
+        .handle(SalesforceQueryExecutionException.class)
+        .withBackoff(Duration.ofSeconds(initialRetryDuration), Duration.ofSeconds(maxRetryDuration), 2)
+        .withMaxRetries(maxRetryCount)
+        .onRetry(event -> {
+          Throwable t = event.getLastException();
+          LOG.warn("Attempt #{} failed while executing job with error: {}", event.getAttemptCount(), t.getMessage(), t);
+          LOG.debug("Retrying Salesforce Bulk Query. Retry count: {}", event.getAttemptCount());
+        })
+        .onRetriesExceeded(event -> LOG.error("Retry limit reached for Salesforce Bulk Query."))
+        .build();
+    } else {
+      return RetryPolicy.builder().withMaxRetries(0).build();
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSource.java
@@ -42,7 +42,6 @@ import io.cdap.plugin.salesforce.SObjectDescriptor;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
-import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import org.apache.spark.streaming.api.java.JavaDStream;
@@ -89,13 +88,22 @@ public class SalesforceStreamingSource extends StreamingSource<StructuredRecord>
         && !config.containsMacro(SalesforceStreamingSourceConfig.PROPERTY_PUSH_TOPIC_QUERY)
         && !config.containsMacro(SalesforceStreamingSourceConfig.PROPERTY_SOBJECT_NAME)
         && oAuthInfo != null) {
-        Schema schema = SalesforceSchemaUtil.getSchema(AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                                    config.getConnection()
-                                                                                      .getConnectTimeout(),
-                                                                                    config.getConnection()
-                                                                                      .getReadTimeout(),
-                                                                                    config.getConnection()
-                                                                                      .getProxyUrl()),
+        Schema schema =
+          SalesforceSchemaUtil.getSchema(AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                                                                 config.getConnection()
+                                                                                   .getConnectTimeout(),
+                                                                                 config.getConnection()
+                                                                                   .getReadTimeout(),
+                                                                                 config.getConnection()
+                                                                                   .getProxyUrl(),
+                                                                                 config.getConnection()
+                                                                                   .getInitialRetryDuration(),
+                                                                                 config.getConnection()
+                                                                                   .getMaxRetryDuration(),
+                                                                                 config.getConnection()
+                                                                                   .getMaxRetryCount(),
+                                                                                 config.getConnection()
+                                                                                   .isRetryOnBackendError()),
                                                        SObjectDescriptor.fromQuery(query));
         pipelineConfigurer.getStageConfigurer().setOutputSchema(schema);
       } else {
@@ -133,8 +141,7 @@ public class SalesforceStreamingSource extends StreamingSource<StructuredRecord>
   @Path("outputSchema")
   public Schema outputSchema(SalesforceStreamingSourceConfig config) throws Exception {
     AuthenticatorCredentials authenticatorCredentials = config.getConnection().getAuthenticatorCredentials();
-    PartnerConnection partnerConnection = new PartnerConnection(
-      Authenticator.createConnectorConfig(authenticatorCredentials));
+    PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(authenticatorCredentials);
     SObject pushTopic =
       SalesforceStreamingSourceConfig.fetchPushTopicByName(partnerConnection, config.getPushTopicName());
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -35,7 +35,6 @@ import io.cdap.plugin.salesforce.SObjectFilterDescriptor;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
-import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.SalesforceConnectorBaseConfig;
@@ -150,12 +149,18 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
                                          @Nullable Integer readTimeout,
                                          @Nullable OAuthInfo oAuthInfo,
                                          @Nullable String proxyUrl,
-                                         @Nullable String schema) {
+                                         @Nullable String schema,
+                                         @Nullable Long initialRetryDuration,
+                                         @Nullable Long maxRetryDuration,
+                                         @Nullable Integer maxRetryCount,
+                                         @Nullable Boolean retryOnBackendError) {
     super(referenceName);
     this.pushTopicName = pushTopicName;
     this.sObjectName = sObjectName;
     this.connection = new SalesforceConnectorConfig(consumerKey, consumerSecret, username, password, loginUrl,
-                                                    securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl);
+                                                    securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl,
+                                                    initialRetryDuration, maxRetryDuration, maxRetryCount,
+                                                    retryOnBackendError);
     this.schema = schema;
   }
 
@@ -232,11 +237,15 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
     }
 
     try {
-      PartnerConnection partnerConnection = new PartnerConnection(
-        Authenticator.createConnectorConfig(AuthenticatorCredentials.fromParameters(oAuthInfo,
-                                                                         this.getConnection().getConnectTimeout(),
-                                                                         this.getConnection().getReadTimeout(),
-                                                                         this.connection.getProxyUrl())));
+      PartnerConnection partnerConnection = SalesforceConnectionUtil.getPartnerConnection(
+        AuthenticatorCredentials.fromParameters(oAuthInfo,
+                                                this.getConnection().getConnectTimeout(),
+                                                this.getConnection().getReadTimeout(),
+                                                this.getConnection().getProxyUrl(),
+                                                this.getConnection().getInitialRetryDuration(),
+                                                this.getConnection().getMaxRetryDuration(),
+                                                this.getConnection().getMaxRetryCount(),
+                                                this.getConnection().isRetryOnBackendError()));
 
       SObject pushTopic = fetchPushTopicByName(partnerConnection, pushTopicName);
       String query = getQuery();

--- a/src/test/java/io/cdap/plugin/salesforce/PartnerConnectionRetryWrapperTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/PartnerConnectionRetryWrapperTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce;
+
+import com.sforce.soap.partner.DescribeGlobalResult;
+import com.sforce.soap.partner.DescribeSObjectResult;
+import com.sforce.soap.partner.GetUserInfoResult;
+import com.sforce.soap.partner.PartnerConnection;
+import com.sforce.soap.partner.PartnerConnectionRetryWrapper;
+import com.sforce.soap.partner.QueryResult;
+import com.sforce.soap.partner.sobject.SObject;
+import com.sforce.ws.ConnectionException;
+import com.sforce.ws.ConnectorConfig;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceQueryExecutionException;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SalesforceSplitUtil.class, PartnerConnectionRetryWrapper.class})
+public class PartnerConnectionRetryWrapperTest {
+  @Mock
+  private PartnerConnection mockConnection;
+  @Mock
+  private PartnerConnectionRetryWrapper mockConnectionWrapper;
+
+  @Before
+  public void setUp() throws Exception {
+    PowerMockito.mockStatic(SalesforceSplitUtil.class);
+    RetryPolicy<Object> dummyPolicy = RetryPolicy.builder().withMaxRetries(2).build();
+    when(SalesforceSplitUtil.getRetryPolicy(anyLong(), anyLong(), anyInt(), anyBoolean())).thenReturn(dummyPolicy);
+    when(mockConnectionWrapper.isRetryableConnectionError(any(ConnectionException.class)))
+      .thenReturn(true);
+
+    ConnectorConfig config = new ConnectorConfig();
+    config.setServiceEndpoint("https://login.salesforce.com/services/Soap/u/59.0");
+    config.setManualLogin(true);
+    mockConnection = mock(PartnerConnection.class);
+    when(mockConnection.getConfig()).thenReturn(config);
+    mockConnectionWrapper = new PartnerConnectionRetryWrapper(mockConnection, dummyPolicy);
+  }
+
+  @Test
+  public void testQueryWithRetry_RetriesThenSucceeds() throws Exception {
+    ConnectionException retryable = new ConnectionException("Connection refused");
+    QueryResult successResult = mock(QueryResult.class);
+    // Simulate two failures followed by a success
+    when(mockConnection.query("SELECT Id FROM Account"))
+      .thenThrow(retryable)
+      .thenThrow(retryable)
+      .thenReturn(successResult);
+    QueryResult result = mockConnectionWrapper.query("SELECT Id FROM Account");
+    assertEquals(successResult, result);
+    verify(mockConnection, times(3)).query("SELECT Id FROM Account");
+  }
+
+  @Test
+  public void testQueryWithRetry_MaxRetriesExceeded() throws Exception {
+    ConnectionException retryable = new ConnectionException("Connection timed out");
+    when(mockConnection.query("SELECT Id FROM Account")).thenThrow(retryable);
+    try {
+      mockConnectionWrapper.query("SELECT Id FROM Account");
+    } catch (FailsafeException e) {
+      assertTrue(e.getCause() instanceof SalesforceQueryExecutionException);
+      assertTrue(e.getCause().getCause() instanceof ConnectionException);
+      verify(mockConnection, times(3)).query("SELECT Id FROM Account");
+    }
+  }
+
+  @Test
+  public void testDescribeGlobalWithRetry_RetriesThenSucceeds() throws Exception {
+    ConnectionException retryable = new ConnectionException("Socket timeout");
+    DescribeGlobalResult expected = mock(DescribeGlobalResult.class);
+    when(mockConnection.describeGlobal())
+      .thenThrow(retryable)
+      .thenThrow(retryable)
+      .thenReturn(expected);
+    DescribeGlobalResult result = mockConnectionWrapper.describeGlobal();
+    assertEquals(expected, result);
+    verify(mockConnection, times(3)).describeGlobal();
+  }
+
+  @Test
+  public void testDescribeGlobalWithRetry_MaxRetriesExceeded() throws Exception {
+    ConnectionException retryable = new ConnectionException("Connection timed out");
+    when(mockConnection.describeGlobal()).thenThrow(retryable);
+    try {
+      mockConnectionWrapper.describeGlobal();
+    } catch (FailsafeException e) {
+      assertTrue(e.getCause() instanceof SalesforceQueryExecutionException);
+      assertTrue(e.getCause().getCause() instanceof ConnectionException);
+      verify(mockConnection, times(3)).describeGlobal();
+    }
+  }
+
+  @Test
+  public void testQueryMoreWithRetry_RetriesThenSucceeds() throws Exception {
+    ConnectionException retryable = new ConnectionException("Connection refused");
+    QueryResult expected = mock(QueryResult.class);
+    when(mockConnection.queryMore("abc123"))
+      .thenThrow(retryable)
+      .thenReturn(expected);
+    QueryResult result = mockConnectionWrapper.queryMore("abc123");
+
+    assertEquals(expected, result);
+    verify(mockConnection, times(2)).queryMore("abc123");
+  }
+
+  @Test
+  public void testDescribeSObjectsWithRetry_RetriesThenSucceeds() throws Exception {
+    ConnectionException retryable = new ConnectionException("Socket timeout");
+    DescribeSObjectResult[] expected = new DescribeSObjectResult[]{
+      mock(DescribeSObjectResult.class)
+    };
+
+    when(mockConnection.describeSObjects(new String[]{"Account"}))
+      .thenThrow(retryable)
+      .thenReturn(expected);
+
+    DescribeSObjectResult[] result = mockConnectionWrapper.describeSObjects(new String[]{"Account"});
+
+    assertArrayEquals(expected, result);
+    verify(mockConnection, times(2)).describeSObjects(new String[]{"Account"});
+  }
+
+
+  @Test
+  public void testGetUserInfoWithRetry_RetriesThenSucceeds() throws Exception {
+    ConnectionException retryable = new ConnectionException("Intermittent error");
+    GetUserInfoResult userInfo = mock(GetUserInfoResult.class);
+    when(userInfo.getOrganizationId()).thenReturn("org123");
+    when(mockConnection.getUserInfo())
+      .thenThrow(retryable)
+      .thenReturn(userInfo);
+    GetUserInfoResult result = mockConnectionWrapper.getUserInfo();
+
+    assertEquals("org123", result.getOrganizationId());
+    verify(mockConnection, times(2)).getUserInfo();
+  }
+
+  @Test
+  public void testRetrieveWithRetry_RetryAndSuccess() throws Exception {
+    ConnectionException retryable = new ConnectionException("Server unavailable");
+    SObject obj = new SObject();
+    SObject[] expected = new SObject[]{obj};
+    when(mockConnection.retrieve("Id,Name", "Account", new String[]{"001xx000003DGbY"}))
+      .thenThrow(retryable)
+      .thenReturn(expected);
+    SObject[] result = mockConnectionWrapper.retrieve("Id,Name", "Account", new String[]{"001xx000003DGbY"});
+    assertArrayEquals(expected, result);
+    verify(mockConnection, times(2)).retrieve("Id,Name", "Account", new String[]{"001xx000003DGbY"});
+  }
+}

--- a/src/test/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentialsTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/authenticator/AuthenticatorCredentialsTest.java
@@ -35,7 +35,7 @@ public class AuthenticatorCredentialsTest {
                 USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL).build();
 
         AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(
-                USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL, null, null, null);
+          USERNAME, PASSWORD, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL, null, null, null, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -46,7 +46,7 @@ public class AuthenticatorCredentialsTest {
                 CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL).build();
 
         AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(
-                null, null, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL, null, null, null);
+          null, null, CONSUMER_KEY, CONSUMER_SECRET, LOGIN_URL, null, null, null, null, null, null, null);
 
         assertEquals(expected, actual);
     }
@@ -55,8 +55,8 @@ public class AuthenticatorCredentialsTest {
     public void buildFromParameters_OAuthFlow() {
         AuthenticatorCredentials expected = AuthenticatorCredentials.getBuilder(O_AUTH_INFO).build();
 
-        AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(O_AUTH_INFO, null, null, null);
-
+        AuthenticatorCredentials actual = AuthenticatorCredentials.fromParameters(O_AUTH_INFO, null, null, null, null,
+                                                                                  null, null, null);
         assertEquals(expected, actual);
     }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
@@ -231,6 +231,10 @@ public abstract class BaseSalesforceBatchSinkETLTest extends BaseSalesforceETLTe
                                     BaseSalesforceETLTest.LOGIN_URL, 30000, 3600, sObject, "Insert", null,
                                     ConcurrencyMode.Parallel.name(), "1000000", "10000", "Fail on Error",
                                     BaseSalesforceETLTest.SECURITY_TOKEN,
-                                    null, null, false);
+                                    null, null, false,
+                                    Long.parseLong(INITIAL_RETRY_DURATION),
+                                    Long.parseLong(MAX_RETRY_DURATION),
+                                    Integer.parseInt(MAX_RETRY_COUNT),
+                                    Boolean.parseBoolean(RETRY_ON_BACKEND_ERROR));
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceETLTest.java
@@ -74,6 +74,14 @@ public abstract class BaseSalesforceETLTest extends HydratorTestBase {
                                                                      "30000");
   protected static final String READ_TIMEOUT = System.getProperty("salesforce.test.readTimeout",
                                                                   "3600");
+  protected static final String INITIAL_RETRY_DURATION = System.getProperty("salesforce.test.initialRetryDuration",
+                                                                            "5");
+  protected static final String MAX_RETRY_DURATION = System.getProperty("salesforce.test.maxRetryDuration",
+                                                                        "80");
+  protected static final String MAX_RETRY_COUNT = System.getProperty("salesforce.test.maxRetryCount",
+                                                                     "5");
+  protected static final String RETRY_ON_BACKEND_ERROR = System.getProperty("salesforce.test.retryOnBackendError",
+                                                                            "true");
   public static final int SOAP_RECORDS_LIMIT = 200;
 
   @Rule
@@ -92,9 +100,14 @@ public abstract class BaseSalesforceETLTest extends HydratorTestBase {
     }
     Integer connectTimeout = Integer.parseInt(CONNECT_TIMEOUT);
     Integer readTimeout = Integer.parseInt(READ_TIMEOUT);
-    AuthenticatorCredentials credentials = AuthenticatorCredentials.fromParameters(USERNAME, PASSWORD, CONSUMER_KEY,
-                                                                        CONSUMER_SECRET, LOGIN_URL, connectTimeout,
-                                                                        readTimeout, null);
+    AuthenticatorCredentials credentials =
+      AuthenticatorCredentials.fromParameters(USERNAME, PASSWORD, CONSUMER_KEY,
+                                              CONSUMER_SECRET, LOGIN_URL, connectTimeout,
+                                              readTimeout, null,
+                                              Long.parseLong(INITIAL_RETRY_DURATION),
+                                              Long.parseLong(MAX_RETRY_DURATION),
+                                              Integer.parseInt(MAX_RETRY_COUNT),
+                                              Boolean.parseBoolean(RETRY_ON_BACKEND_ERROR));
     partnerConnection = SalesforceConnectionUtil.getPartnerConnection(credentials);
   }
 

--- a/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSinkSchemaValidation.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSinkSchemaValidation.java
@@ -68,7 +68,7 @@ public class SalesforceBatchSinkSchemaValidation {
                                "1000000", "10000",
                                "Fail on Error",
                                BaseSalesforceETLTest.SECURITY_TOKEN,
-                               null, null, true));
+                               null, null, true, 5L, 10L, 5, true));
     Schema schema = Schema.recordOf("output",
                                     Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("StageName", Schema.of(Schema.Type.STRING)),
@@ -138,7 +138,7 @@ public class SalesforceBatchSinkSchemaValidation {
                                "1000000", "10000",
                                "Fail on Error",
                                BaseSalesforceETLTest.SECURITY_TOKEN,
-                               null, null, true));
+                               null, null, true, 5L, 10L, 5, true));
     Schema schema = Schema.recordOf("output",
                                     Schema.Field.of("Name", Schema.of(Schema.Type.STRING)));
     Field field = new Field();

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBulkRecordReaderTest.java
@@ -24,6 +24,7 @@ import dev.failsafe.FailsafeException;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.salesforce.SalesforceSchemaUtil;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -293,10 +294,13 @@ public class SalesforceBulkRecordReaderTest {
     }
 
     BulkConnection mock = Mockito.mock(BulkConnection.class);
+    BulkConnectionRetryWrapper retryWrappermock = Mockito.mock(BulkConnectionRetryWrapper.class);
     SalesforceBulkRecordReader reader = new SalesforceBulkRecordReader(schema, jobId, batchId, resultIds, mock);
     FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("bulkConnection"), mock);
+    FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("bulkConnectionRetryWrapper"),
+                         retryWrappermock);
     for (int i = 0; i < csvStrings.length; i++) {
-      Mockito.when(mock.getQueryResultStream(jobId, batchId, resultIds[i]))
+      Mockito.when(retryWrappermock.getQueryResultStream(jobId, batchId, resultIds[i]))
         .thenReturn(new ByteArrayInputStream(csvStrings[i].getBytes(StandardCharsets.UTF_8)));
     }
     reader.setupParser();
@@ -342,7 +346,7 @@ public class SalesforceBulkRecordReaderTest {
     );
 
     Assert.assertEquals(5, SalesforceSplitUtil.getRetryPolicy
-      (initialRetryDuration, maxRetryDuration, maxRetryCount).getConfig().getMaxRetries());
+      (initialRetryDuration, maxRetryDuration, maxRetryCount, true).getConfig().getMaxRetries());
       assertRecordReaderOutputRecordsRetryMechanism(new String[]{csvString1, csvString2}, schema);
   }
 
@@ -364,13 +368,10 @@ public class SalesforceBulkRecordReaderTest {
         .thenThrow(salesforceQueryExecutionException);
       Mockito.when(salesforceQueryExecutionException.getExceptionCode()).thenReturn(AsyncExceptionCode.Unknown);
     }
-    FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("initialRetryDuration")
-      , 1L);
-    FieldSetter.setField(reader, SalesforceBulkRecordReader.class.getDeclaredField("maxRetryDuration"), 10L);
     reader.setupParser();
   }
 
-  @Test (expected = FailsafeException.class)
+  @Test(expected = AsyncApiException.class)
   public void testSetupParserWithoutRetry() throws Exception {
     String csvString1 = "\"Id\",\"IsDeleted\",\"ExpectedRevenue\",\"LastModifiedDate\",\"CloseDate\",\"Time\"\n" +
       "\"0061i000003XNcBAAW\",\"false\",\"1500.0\",\"2019-02-22T07:03:21.000Z\",\"2019-01-01\",\"12:00:30.000Z\"\n";

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
@@ -276,7 +276,9 @@ public class SalesforceSourceConfigTest {
                                                                         Mockito.anyString(), Mockito.anyString(),
                                                                         Mockito.anyString(), Mockito.anyString(),
                                                                         Mockito.any(), Mockito.any(), Mockito.any(),
-                                                                        Mockito.anyString())
+                                                                        Mockito.anyString(), Mockito.anyLong(),
+                                                                        Mockito.anyLong(), Mockito.anyInt(),
+                                                                        Mockito.anyBoolean())
       .thenReturn(connectorConfig);
     SalesforceConnectorInfo salesforceConnectorInfo =
       new SalesforceConnectorInfo(null, connectorConfig,

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -31,6 +31,7 @@
   <suppress checks="RedundantModifier" files=".*[/\\]src[/\\]test[/\\]java[/\\].*" />
 
   <suppress files="com/sforce/async/BulkConnection\.java" checks=".*"/>
+  <suppress files="com/sforce/soap/partner/PartnerConnectionRetryWrapper\.java" checks=".*"/>
 
   <!-- copied from apache hadoop, won't fix style to keep diff minimal  -->
   <suppress checks=".*" files=".*[/\\]LocalJobRunnerWithFix.java" />

--- a/widgets/Salesforce-connector.json
+++ b/widgets/Salesforce-connector.json
@@ -77,6 +77,49 @@
             "min": "0",
             "default": "3600"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Initial Retry Duration",
+          "name": "initialRetryDuration",
+          "widget-attributes": {
+            "min": "1",
+            "default": "5"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Duration",
+          "name": "maxRetryDuration",
+          "widget-attributes": {
+            "min": "6",
+            "default": "80"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Count",
+          "name": "maxRetryCount",
+          "widget-attributes": {
+            "min": "1",
+            "default": "5"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Retry On Backend Error",
+          "name": "retryOnBackendError",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "true"
+          }
         }
       ]
     },

--- a/widgets/Salesforce-streamingsource.json
+++ b/widgets/Salesforce-streamingsource.json
@@ -95,6 +95,49 @@
             "min": "0",
             "default": "3600"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Initial Retry Duration",
+          "name": "initialRetryDuration",
+          "widget-attributes": {
+            "min": "1",
+            "default": "5"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Duration",
+          "name": "maxRetryDuration",
+          "widget-attributes": {
+            "min": "6",
+            "default": "80"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Max Retry Count",
+          "name": "maxRetryCount",
+          "widget-attributes": {
+            "min": "1",
+            "default": "5"
+          }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Retry On Backend Error",
+          "name": "retryOnBackendError",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "true"
+          }
         }
       ]
     },


### PR DESCRIPTION
[PLUGIN - 1908](https://cdap.atlassian.net/browse/PLUGIN-1908) 
Implemented retry logic for Salesforce PartnerConnection SOAP API calls and wrapped critical PartnerConnection methods inside class PartnerConnectionRetryWrapper with retry support.

Cheerypick of PR : https://github.com/data-integrations/salesforce/pull/308