### PR TITLE
[cherrypick] [PLUGIN-1916] Added validation for unsupported sObjects

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -85,12 +85,12 @@ public class SalesforceConstants {
   // SControl, EmailCapture, MailmergeTemplate contains binary fields which will cause the batch read to fail.
   public static final Set<String> UNSUPPORTED_BULK_API_OBJECTS = Collections.unmodifiableSet(
     new HashSet<>(Arrays.asList(
-      "Attachment", "ContentVersion", "Document", "StaticResource", "SControl",
-      "EmailCapture", "MailmergeTemplate", "AcceptedEventRelation", "CaseStatus",
-      "ContentFolderItem", "ContractStatus", "DeclinedEventRelation",
-      "FieldSecurityClassification", "OrderStatus", "PartnerRole", "RecentlyViewed",
-      "SolutionStatus", "TaskPriority", "TaskStatus", "UndecidedEventRelation",
-      "UserRecordAccess", "WorkOrderLineItemStatus", "WorkOrderStatus"
+      "attachment", "contentversion", "document", "staticresource", "scontrol",
+      "emailcapture", "mailmergetemplate", "acceptedeventrelation", "casestatus",
+      "contentfolderitem", "contractstatus", "declinedeventrelation",
+      "fieldsecurityclassification", "orderstatus", "partnerrole", "recentlyviewed",
+      "solutionstatus", "taskpriority", "taskstatus", "undecidedeventrelation",
+      "userrecordaccess", "workorderlineitemstatus", "workorderstatus"
     )));
 
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnector.java
@@ -128,7 +128,7 @@ public class SalesforceConnector implements DirectConnector {
         // Continue in case of returning only queryable sObjects and the current sObject is non-queryable.
         // Continue if sObject is not supported by Bulk APIs
         if (onlyReturnQueryableObjects &&
-          (!isQueryable || SalesforceConstants.UNSUPPORTED_BULK_API_OBJECTS.contains(name))) {
+          (!isQueryable || SalesforceConstants.UNSUPPORTED_BULK_API_OBJECTS.contains(name.toLowerCase()))) {
           continue;
         }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -197,6 +197,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
       try {
         boolean isSoql = isSoqlQuery();
         if (!isSoql) {
+          validateSobject(collector);
           validateFilters(collector);
         }
       } catch (InvalidConfigException e) {
@@ -353,6 +354,13 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
       collector.addFailure(String.format("There was issue communicating with Salesforce due to error: %s", message),
                            null).withStacktrace(e.getStackTrace());
       throw collector.getOrThrowException();
+    }
+  }
+
+  public void validateSobject(FailureCollector collector) {
+    if (SalesforceConstants.UNSUPPORTED_BULK_API_OBJECTS.contains(sObjectName.toLowerCase())) {
+      collector.addFailure(String.format("sObject type '%s' is not supported", sObjectName), null)
+        .withConfigProperty(SalesforceSourceConstants.PROPERTY_SOBJECT_NAME);
     }
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
@@ -249,6 +249,15 @@ public class SalesforceSourceConfigTest {
   }
 
   @Test
+  public void testInvalidSObjectValidation() throws Exception {
+    SalesforceSourceConfig config = new SalesforceSourceConfigBuilder()
+        .setReferenceName("Source")
+        .setSObjectName("Attachment")
+        .build();
+    testInvalidSObjectConfig(config, SalesforceSourceConstants.PROPERTY_SOBJECT_NAME);
+  }
+
+  @Test
   public void testPKChunkWithChunkSizeAboveMax() throws Exception {
     SalesforceSourceConfig config = new SalesforceSourceConfigBuilder()
       .setQuery("Select Name from Table")
@@ -297,4 +306,29 @@ public class SalesforceSourceConfigTest {
     }
     Assert.assertEquals(stageConfigName, failure.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
   }
+
+  private void testInvalidSObjectConfig(SalesforceSourceConfig config, String stageConfigName) throws Exception {
+    MockFailureCollector collector = new MockFailureCollector();
+    SalesforceSourceConfig mock = Mockito.spy(config);
+
+    SalesforceConnectorConfig connectorConfig = Mockito.mock(SalesforceConnectorConfig.class);
+    PowerMockito.whenNew(SalesforceConnectorConfig.class).withAnyArguments().thenReturn(connectorConfig);
+
+    SalesforceConnectorInfo salesforceConnectorInfo =
+        new SalesforceConnectorInfo(null, connectorConfig,
+            SalesforceConstants.isOAuthMacroFunction.apply(connectorConfig));
+
+    Mockito.when(mock.getConnection()).thenReturn(salesforceConnectorInfo);
+    PowerMockito.when(salesforceConnectorInfo.canAttemptToEstablishConnection()).thenReturn(false);
+
+    ValidationFailure failure = null;
+      mock.validate(collector, null);
+      failure = collector.getValidationFailures().get(0);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+    Assert.assertEquals(stageConfigName,
+        failure.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+    String expectedMessage = "sObject type 'Attachment' is not supported";
+    Assert.assertEquals(expectedMessage, failure.getMessage());
+  }
+
 }


### PR DESCRIPTION
[cherrypick] [PLUGIN-1916] Added validation for unsupported sObjects

Cherrypick of PR #324 

[PLUGIN-1916]: https://cdap.atlassian.net/browse/PLUGIN-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ