### PR TITLE
Updated Maven repository URL from Sonatype snapshots to Airlock’s ah-3p-staging-maven repository (MOSS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,16 @@
 
   <repositories>
     <repository>
-      <id>sonatype-snapshots</id>
-      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+      <id>central</id>
+      <name>Maven Central remote repository</name>
+      <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/ah-3p-staging-maven</url>
+      <layout>default</layout>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Updated Maven repository URL from Sonatype snapshots to Airlock’s ah-3p-staging-maven repository to align with MOSS Phase 1 requirements. This change helps move dependencies closer to the trusted Airlock ecosystem while we work towards full migration to maven-3p-trusted.

Buganizer - https://buganizer.corp.google.com/issues/434589240