### PR TITLE
Bump up version to: 1.6.15-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <name>Salesforce plugins</name>
   <groupId>io.cdap.plugin</groupId>
   <artifactId>salesforce-plugins</artifactId>
-  <version>1.6.14</version>
+  <version>1.6.15-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Salesforce Plugins</description>
   <url>https://github.com/data-integrations/salesforce</url>


### PR DESCRIPTION
Bump up version to `1.6.15-SNAPSHOT` for preparing release candidate: `1.6.15`