### PR TITLE
Cherry-pick: Jetty HTTP Upgrade 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <name>Salesforce plugins</name>
   <groupId>io.cdap.plugin</groupId>
   <artifactId>salesforce-plugins</artifactId>
-  <version>1.7.1</version>
+  <version>1.7.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Salesforce Plugins</description>
   <url>https://github.com/data-integrations/salesforce</url>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.13</version>
     </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+          <version>9.4.52.v20230823</version>
+      </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
@@ -256,6 +261,12 @@
       <groupId>org.cometd.java</groupId>
       <artifactId>cometd-java-client</artifactId>
       <version>${cometd.java.client.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>


### PR DESCRIPTION
<img width="1913" height="722" alt="image (6)" src="https://github.com/user-attachments/assets/c690bf73-d294-4a66-a3a2-057794017b25" />

**Issue:**
Jetty (org.eclipse.jetty:jetty-http:9.4.12.v20180830) – Jetty accepts the '+' character preceding the Content-Length value in an HTTP/1 header field. This behavior is more permissive than allowed by the RFC and can potentially lead to HTTP request smuggling when Jetty is used in combination with servers that reject such requests (e.g., NGINX, Apache).

Even though no active exploit has been reported, the issue could enable attackers to bypass security controls such as WAF or IDS when different components interpret the same request differently.

**Root Cause:**
Jetty’s HTTP parser accepts a '+' sign before numeric values in the Content-Length header (e.g., Content-Length: +16), which violates RFC 9110 Section 8.6
.
This inconsistency in request parsing can cause mismatched interpretations between Jetty and other proxy or upstream servers, potentially leading to request smuggling or partial request injection scenarios.

**CVEs:**

- CVE-2023-40167
- CVE-2022-2047

**Fix**:
Upgraded the Jetty HTTP dependency from version **9.4.12.v20180830** to **9.4.52.v20230823**, where this issue is fixed.
Upgrade Salesforce version from **1.7.1** to **1.7.2-SNAPSHOT**

**CVE Fix Verification**: https://screenshot.googleplex.com/7LZHErfRWhVPdWF

*JIRA* : [[PLUGIN-1934](https://cdap.atlassian.net/browse/PLUGIN-1934)]

[PLUGIN-1934]: https://cdap.atlassian.net/browse/PLUGIN-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ