### PR TITLE
CVE-2025-48734 Fix : Beanutils commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,6 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.13</version>
     </dependency>
-      <dependency>
-          <groupId>org.eclipse.jetty</groupId>
-          <artifactId>jetty-http</artifactId>
-          <version>9.4.52.v20230823</version>
-      </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
@@ -265,12 +260,6 @@
       <groupId>org.cometd.java</groupId>
       <artifactId>cometd-java-client</artifactId>
       <version>${cometd.java.client.version}</version>
-        <exclusions>
-            <exclusion>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-http</artifactId>
-            </exclusion>
-        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <spark2.version>2.1.3</spark2.version>
     <hydrator.version>2.10.0</hydrator.version>
     <commons.version>3.18.0</commons.version>
-    <salesforce.api.version>64.0.0</salesforce.api.version>
+    <salesforce.api.version>65.0.0</salesforce.api.version>
     <cometd.java.client.version>4.0.0</cometd.java.client.version>
     <antlr.version>4.7.2</antlr.version>
     <mockito.version>2.23.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.13</version>
     </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+          <version>9.4.52.v20230823</version>
+      </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
@@ -256,6 +261,12 @@
       <groupId>org.cometd.java</groupId>
       <artifactId>cometd-java-client</artifactId>
       <version>${cometd.java.client.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+          <exclusion>
+              <groupId>commons-beanutils</groupId>
+              <artifactId>commons-beanutils</artifactId>
+          </exclusion>
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>


### PR DESCRIPTION
**Issue**:
Apache Commons BeanUtils versions prior to 1.11.0 (1.x) and 2.0.0-M2 (2.x) allowed unauthorized access to the declaredClass property of Java enum objects via PropertyUtilsBean.getProperty() or PropertyUtilsBean.getNestedProperty(). This vulnerability could allow an attacker to access the enum’s classloader and potentially execute arbitrary code. The root cause was that the protective BeanIntrospector introduced in version 1.9.2 was not enabled by default in older versions.

**Root Cause**:
PropertyUtilsBean allowed access to the declaredClass property of enum objects, enabling attackers to access the ClassLoader. The protective BeanIntrospector introduced in version 1.9.2 suppressed access to declaredClass but was not enabled by default.

**Fix**:
Upgraded commons-beanutils:commons-beanutils from version 1.9.4 to 1.11.0. This upgrade enables the protective BeanIntrospector by default, preventing unauthorized access to enum classloaders.
The fix is included as part of the forced wsc library upgrade from 64.0.0 to 65.0.0, which brought in the updated BeanUtils version.

**CVE Fix Verification**: https://screenshot.googleplex.com/AGvRfJfiYfk4W4E

**Pipeline Run**: https://screenshot.googleplex.com/8UraQyBsrsHhFJA

_JIRA_ : [[PLUGIN-1937](https://cdap.atlassian.net/browse/PLUGIN-1937)]





[PLUGIN-1937]: https://cdap.atlassian.net/browse/PLUGIN-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ