### PR TITLE
[🍒][PLUGIN-1937] CVE-2025-48734 Fix : Beanutils commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,10 @@
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
+          <exclusion>
+              <groupId>commons-beanutils</groupId>
+              <artifactId>commons-beanutils</artifactId>
+          </exclusion>
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <spark2.version>2.1.3</spark2.version>
     <hydrator.version>2.10.0</hydrator.version>
     <commons.version>3.18.0</commons.version>
-    <salesforce.api.version>64.0.0</salesforce.api.version>
+    <salesforce.api.version>65.0.0</salesforce.api.version>
     <cometd.java.client.version>4.0.0</cometd.java.client.version>
     <antlr.version>4.7.2</antlr.version>
     <mockito.version>2.23.0</mockito.version>


### PR DESCRIPTION
[🍒]

🍒 [cherrypick]

Commits:

- https://github.com/data-integrations/salesforce/commit/c02017afb054251c317b6e8a7f408a7902148d45


PR:

- https://github.com/data-integrations/salesforce/pull/341 [ Reviewer: @minurajeeve ]


Description:

[PLUGIN-1937](https://cdap.atlassian.net/browse/PLUGIN-1937): This [PR](https://github.com/data-integrations/salesforce/pull/341) upgrades the version of commons-beanutils library from v1.9.4 to v1.11.0, thereby fixing the vulnerability that allowed unauthorized access to the declaredClass property of Java enum objects via PropertyUtilsBean.getProperty() or PropertyUtilsBean.getNestedProperty().

Fix: Upgraded commons-beanutils:commons-beanutils from version 1.9.4 to 1.11.0. This upgrade enables the protective BeanIntrospector by default, preventing unauthorized access to enum classloaders. The fix is included as part of the forced WSC library upgrade from 64.0.0 to 65.0.0, which brought in the updated BeanUtils version.

CVE Fix Verification: https://screenshot.googleplex.com/AGvRfJfiYfk4W4E

Pipeline Run: https://screenshot.googleplex.com/8UraQyBsrsHhFJA

JIRA: [PLUGIN-1937]



[PLUGIN-1937]: https://cdap.atlassian.net/browse/PLUGIN-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUGIN-1937]: https://cdap.atlassian.net/browse/PLUGIN-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ