### PR TITLE
[🍒][PLUGIN-1934]: Fix CVEs in jetty-http 9.4.12.v20180830 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.13</version>
     </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+          <version>9.4.52.v20230823</version>
+      </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>
@@ -260,6 +265,12 @@
       <groupId>org.cometd.java</groupId>
       <artifactId>cometd-java-client</artifactId>
       <version>${cometd.java.client.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.antlr</groupId>


### PR DESCRIPTION
[🍒]

🍒 [cherrypick]

Commits:

- https://github.com/data-integrations/salesforce/pull/339/commits/eafcba0663575b6fbfb48c8b2e8af02b2235c317


PR:

- https://github.com/data-integrations/salesforce/pull/339 [ Reviewer: @minurajeeve ]


**Description**:

[PLUGIN-1934](https://cdap.atlassian.net/browse/PLUGIN-1934): This [PR](https://github.com/data-integrations/salesforce/pull/339) upgrades the Jetty HTTP dependency to address an issue where Jetty accepted a '+' character preceding the Content-Length value in HTTP/1 headers. This behavior was more permissive than allowed by the RFC and could potentially lead to HTTP request smuggling when Jetty is used alongside servers that strictly validate such headers (e.g., NGINX, Apache).

**Fix**: Upgraded the Jetty HTTP dependency from version 9.4.12.v20180830 to 9.4.52.v20230823, where strict validation of the Content-Length header is enforced and the issue is resolved.

**CVE Fix Verification**: https://screenshot.googleplex.com/7RjXpjeSc7rx4zr

**Pipeline Run**: https://screenshot.googleplex.com/AcYid2CdAbnhkeK


**JIRA**: [PLUGIN-1934](https://cdap.atlassian.net/browse/PLUGIN-1934)

[PLUGIN-1934]: https://cdap.atlassian.net/browse/PLUGIN-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUGIN-1934]: https://cdap.atlassian.net/browse/PLUGIN-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ