### PR TITLE
[PLUGIN-1953] Support for client credentials Grant type

### DIFF
--- a/docs/Salesforce-batchsink.md
+++ b/docs/Salesforce-batchsink.md
@@ -16,12 +16,16 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Reference Name:** Name used to uniquely identify this sink for lineage, annotating metadata, etc.
 
-**Username:** Salesforce username.
+**Grant Type:** Grant type to use for OAuth authentication. Supported values are 'password' and
+'client_credentials'. When set to 'client_credentials', only Consumer Key, Consumer Secret, and Login URL
+are required. Username, Password, and Security Token are not needed. Defaults to 'password' if not specified.
 
-**Password:** Salesforce password.
+**Username:** Salesforce username. Required for 'password' grant type.
 
-**Security Token:** Salesforce security token. If the password does not contain the security token, the plugin 
-will append the token before authenticating with Salesforce.
+**Password:** Salesforce password. Required for 'password' grant type.
+
+**Security Token:** Salesforce security token. If the password does not contain the security token, the plugin
+will append the token before authenticating with Salesforce. Only applicable for 'password' grant type.
 
 **Consumer Key:** Application Consumer Key. This is also known as the OAuth client ID.
 A Salesforce connected application must be created in order to get a consumer key.
@@ -29,7 +33,10 @@ A Salesforce connected application must be created in order to get a consumer ke
 **Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
 A Salesforce connected application must be created in order to get a client secret.
 
-**Login URL:** Salesforce OAuth2 login URL.
+**Login URL:** Salesforce OAuth2 login URL. For the 'password' grant type, the default generic URL
+`https://login.salesforce.com/services/oauth2/token` can be used. For the 'client_credentials' grant type,
+you must provide your Salesforce instance-specific URL, for example
+`https://<your-instance>.my.salesforce.com/services/oauth2/token`.
 
 **Connect Timeout:** Maximum time in milliseconds to wait for connection initialization before it times out.
 

--- a/docs/Salesforce-batchsource.md
+++ b/docs/Salesforce-batchsource.md
@@ -18,12 +18,16 @@ Configuration
 
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**Username:** Salesforce username.
+**Grant Type:** Grant type to use for OAuth authentication. Supported values are 'password' and
+'client_credentials'. When set to 'client_credentials', only Consumer Key, Consumer Secret, and Login URL
+are required. Username, Password, and Security Token are not needed. Defaults to 'password' if not specified.
 
-**Password:** Salesforce password.
+**Username:** Salesforce username. Required for 'password' grant type.
 
-**Security Token:** Salesforce security token. If the password does not contain the security token the plugin, 
-will append the token before authenticating with Salesforce.
+**Password:** Salesforce password. Required for 'password' grant type.
+
+**Security Token:** Salesforce security token. If the password does not contain the security token the plugin,
+will append the token before authenticating with Salesforce. Only applicable for 'password' grant type.
 
 **Consumer Key:** Application Consumer Key. This is also known as the OAuth client ID.
 A Salesforce connected application must be created in order to get a consumer key.
@@ -31,7 +35,10 @@ A Salesforce connected application must be created in order to get a consumer ke
 **Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
 A Salesforce connected application must be created in order to get a client secret.
 
-**Login URL:** Salesforce OAuth2 login URL.
+**Login URL:** Salesforce OAuth2 login URL. For the 'password' grant type, the default generic URL
+`https://login.salesforce.com/services/oauth2/token` can be used. For the 'client_credentials' grant type,
+you must provide your Salesforce instance-specific URL, for example
+`https://<your-instance>.my.salesforce.com/services/oauth2/token`.
 
 **Connect Timeout:** Maximum time in milliseconds to wait for connection initialization before it times out.
 

--- a/docs/Salesforce-connector.md
+++ b/docs/Salesforce-connector.md
@@ -10,12 +10,16 @@ Properties
 
 **Description:** Description of the connection.
 
-**Username:** Salesforce username.
+**Grant Type:** Grant type to use for OAuth authentication. Supported values are 'password' and
+'client_credentials'. When set to 'client_credentials', only Consumer Key, Consumer Secret, and Login URL
+are required. Username, Password, and Security Token are not needed. Defaults to 'password' if not specified.
 
-**Password:** Salesforce password.
+**Username:** Salesforce username. Required for 'password' grant type.
+
+**Password:** Salesforce password. Required for 'password' grant type.
 
 **Security Token:** Salesforce security token. If the password does not contain the security token, the plugin
-will append the token before authenticating with Salesforce.
+will append the token before authenticating with Salesforce. Only applicable for 'password' grant type.
 
 **Consumer Key:** Application Consumer Key. This is also known as the OAuth client ID.
 A Salesforce connected application must be created in order to get a consumer key.
@@ -23,7 +27,10 @@ A Salesforce connected application must be created in order to get a consumer ke
 **Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
 A Salesforce connected application must be created in order to get a client secret.
 
-**Login URL:** Salesforce OAuth2 login URL.
+**Login URL:** Salesforce OAuth2 login URL. For the 'password' grant type, the default generic URL
+`https://login.salesforce.com/services/oauth2/token` can be used. For the 'client_credentials' grant type,
+you must provide your Salesforce instance-specific URL, for example
+`https://<your-instance>.my.salesforce.com/services/oauth2/token`.
 
 **Connect Timeout:** Maximum time in milliseconds to wait for connection initialization before it times out.
 

--- a/docs/Salesforce-streamingsource.md
+++ b/docs/Salesforce-streamingsource.md
@@ -21,12 +21,16 @@ Configuration
 
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**Username:** Salesforce username.
+**Grant Type:** Grant type to use for OAuth authentication. Supported values are 'password' and
+'client_credentials'. When set to 'client_credentials', only Consumer Key, Consumer Secret, and Login URL
+are required. Username, Password, and Security Token are not needed. Defaults to 'password' if not specified.
 
-**Password:** Salesforce password.
+**Username:** Salesforce username. Required for 'password' grant type.
 
-**Security Token:** Salesforce security token. If the password does not contain the security token, the plugin 
-will append the token before authenticating with Salesforce.
+**Password:** Salesforce password. Required for 'password' grant type.
+
+**Security Token:** Salesforce security token. If the password does not contain the security token, the plugin
+will append the token before authenticating with Salesforce. Only applicable for 'password' grant type.
 
 **Consumer Key:** Application Consumer Key. This is also known as the OAuth client ID.
 A Salesforce connected application must be created in order to get a consumer key.
@@ -34,7 +38,10 @@ A Salesforce connected application must be created in order to get a consumer ke
 **Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
 A Salesforce connected application must be created in order to get a client secret.
 
-**Login URL:** Salesforce OAuth2 login URL.
+**Login URL:** Salesforce OAuth2 login URL. For the 'password' grant type, the default generic URL
+`https://login.salesforce.com/services/oauth2/token` can be used. For the 'client_credentials' grant type,
+you must provide your Salesforce instance-specific URL, for example
+`https://<your-instance>.my.salesforce.com/services/oauth2/token`.
 
 **Connect Timeout:** Maximum time in milliseconds to wait for connection initialization before it times out.
 

--- a/docs/SalesforceMultiObjects-batchsource.md
+++ b/docs/SalesforceMultiObjects-batchsource.md
@@ -18,12 +18,16 @@ Configuration
 
 **Reference Name:** Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
-**Username:** Salesforce username.
+**Grant Type:** Grant type to use for OAuth authentication. Supported values are 'password' and
+'client_credentials'. When set to 'client_credentials', only Consumer Key, Consumer Secret, and Login URL
+are required. Username, Password, and Security Token are not needed. Defaults to 'password' if not specified.
 
-**Password:** Salesforce password.
+**Username:** Salesforce username. Required for 'password' grant type.
 
-**Security Token:** Salesforce security token. If the password does not contain the security token, the plugin 
-will append the token before authenticating with Salesforce.
+**Password:** Salesforce password. Required for 'password' grant type.
+
+**Security Token:** Salesforce security token. If the password does not contain the security token, the plugin
+will append the token before authenticating with Salesforce. Only applicable for 'password' grant type.
 
 **Consumer Key:** Application Consumer Key. This is also known as the OAuth client ID.
 A Salesforce connected application must be created in order to get a consumer key.
@@ -31,7 +35,10 @@ A Salesforce connected application must be created in order to get a consumer ke
 **Consumer Secret:** Application Consumer Secret. This is also known as the OAuth client secret.
 A Salesforce connected application must be created in order to get a client secret.
 
-**Login URL:** Salesforce OAuth2 login URL.
+**Login URL:** Salesforce OAuth2 login URL. For the 'password' grant type, the default generic URL
+`https://login.salesforce.com/services/oauth2/token` can be used. For the 'client_credentials' grant type,
+you must provide your Salesforce instance-specific URL, for example
+`https://<your-instance>.my.salesforce.com/services/oauth2/token`.
 
 **Connect Timeout:** Maximum time in milliseconds to wait for connection initialization before time out.
 

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
@@ -123,6 +123,7 @@ public class SalesforceConnectionUtil {
     if (!config.canAttemptToEstablishConnection()) {
       return null;
     }
+    config.validateAuthenticationFields(collector);
     OAuthInfo oAuthInfo = null;
     try {
       oAuthInfo = Authenticator.getOAuthInfo(config.getAuthenticatorCredentials());

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConstants.java
@@ -16,6 +16,7 @@
 package io.cdap.plugin.salesforce;
 
 import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials.GrantType;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,10 +66,14 @@ public class SalesforceConstants {
   public static final String CONFIG_MAX_RETRY_DURATION = "mapred.salesforce.maxRetryDuration";
   public static final String CONFIG_MAX_RETRY_COUNT = "mapred.salesforce.maxRetryCount";
   public static final String CONFIG_RETRY_REQUIRED = "mapred.salesforce.retryOnBackendError";
+  public static final String CONFIG_GRANT_TYPE = "mapred.salesforce.grantType";
 
   public static final String PROPERTY_PROXY_URL = "proxyUrl";
   public static final String CONFIG_PROXY_URL = "mapred.salesforce.proxyUrl";
   public static final String REGEX_PROXY_URL = "^(?i)(https?)://.*$";
+
+  public static final String PROPERTY_AUTHENTICATION_GRANT_TYPE = "authenticationGrantType";
+  public static final GrantType DEFAULT_GRANT_TYPE = GrantType.PASSWORD;
 
   public static final String PROPERTY_MAX_RETRY_TIME_IN_MINS = "cdap.streaming.maxRetryTimeInMins";
   public static final long DEFAULT_MAX_RETRY_TIME_IN_MINS = 360L;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfig.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.salesforce.plugin;
 
+import com.google.common.base.Strings;
 import com.sforce.ws.ConnectionException;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
@@ -24,6 +25,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials.GrantType;
 
 import javax.annotation.Nullable;
 
@@ -31,6 +33,12 @@ import javax.annotation.Nullable;
  * Base configuration for Salesforce Streaming and Batch plugins
  */
 public class SalesforceConnectorBaseConfig extends PluginConfig {
+
+  @Name(SalesforceConstants.PROPERTY_AUTHENTICATION_GRANT_TYPE)
+  @Description("Salesforce authentication grant type: basic or client credentials")
+  @Nullable
+  @Macro
+  protected String authenticationGrantType;
 
   @Nullable
   @Name(SalesforceConstants.PROPERTY_PROXY_URL)
@@ -81,7 +89,11 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
   private final String securityToken;
 
   @Name(SalesforceConstants.PROPERTY_LOGIN_URL)
-  @Description("Endpoint to authenticate to")
+  @Description("Salesforce OAuth2 login URL. For the 'password' grant type, the default generic URL\n" +
+          "`https://login.salesforce.com/services/oauth2/token` can be used. " +
+          "For the 'client_credentials' grant type,\n" +
+          "you must provide your Salesforce instance-specific URL, for example\n" +
+          "`https://<your-instance>.my.salesforce.com/services/oauth2/token`.")
   @Macro
   @Nullable
   private final String loginUrl;
@@ -118,7 +130,8 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
                                        @Nullable Long initialRetryDuration,
                                        @Nullable Long maxRetryDuration,
                                        @Nullable Integer maxRetryCount,
-                                       @Nullable Boolean retryOnBackendError) {
+                                       @Nullable Boolean retryOnBackendError,
+                                       @Nullable String authenticationGrantType) {
     this.consumerKey = consumerKey;
     this.consumerSecret = consumerSecret;
     this.username = username;
@@ -132,6 +145,16 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
     this.maxRetryDuration = maxRetryDuration;
     this.retryOnBackendError = retryOnBackendError;
     this.maxRetryCount = maxRetryCount;
+    this.authenticationGrantType = authenticationGrantType;
+  }
+
+  public GrantType getAuthenticationGrantType() {
+    if (!Strings.isNullOrEmpty(authenticationGrantType) &&
+            authenticationGrantType.equals(GrantType.CLIENT_CREDENTIALS.getType())) {
+      return GrantType.CLIENT_CREDENTIALS;
+    }
+    // Default auth, handles null case when upgrading pipeline
+    return SalesforceConstants.DEFAULT_GRANT_TYPE;
   }
 
   @Nullable
@@ -230,6 +253,56 @@ public class SalesforceConnectorBaseConfig extends PluginConfig {
   @Nullable
   public String getProxyUrl() {
     return proxyUrl;
+  }
+
+  /**
+   * Validates that required authentication fields are present based on the selected OAuth grant type.
+   * For PASSWORD grant type: consumerKey, consumerSecret, username, password, and loginUrl are required.
+   * For CLIENT_CREDENTIALS grant type: consumerKey, consumerSecret, and loginUrl are required.
+   *
+   * @param collector the failure collector to report validation errors
+   */
+  public void validateAuthenticationFields(FailureCollector collector) {
+    if (containsMacro(SalesforceConstants.PROPERTY_AUTHENTICATION_GRANT_TYPE)) {
+      return;
+    }
+
+    // Fields required for all grant types
+    if (!containsMacro(SalesforceConstants.PROPERTY_CONSUMER_KEY) && Strings.isNullOrEmpty(consumerKey)) {
+      collector.addFailure("Consumer Key is required for authentication.",
+                           "Please provide the Consumer Key from your Salesforce connected app.")
+        .withConfigProperty(SalesforceConstants.PROPERTY_CONSUMER_KEY);
+    }
+    if (!containsMacro(SalesforceConstants.PROPERTY_CONSUMER_SECRET) && Strings.isNullOrEmpty(consumerSecret)) {
+      collector.addFailure("Consumer Secret is required for authentication.",
+                           "Please provide the Consumer Secret from your Salesforce connected app.")
+        .withConfigProperty(SalesforceConstants.PROPERTY_CONSUMER_SECRET);
+    }
+    if (!containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL) && Strings.isNullOrEmpty(loginUrl)) {
+      collector.addFailure("Login URL is required for authentication.",
+                           "Please provide the Salesforce login URL.")
+        .withConfigProperty(SalesforceConstants.PROPERTY_LOGIN_URL);
+    }
+
+    GrantType grantType = getAuthenticationGrantType();
+    // Fields required only for PASSWORD grant type
+    if (grantType == GrantType.PASSWORD) {
+      if (!containsMacro(SalesforceConstants.PROPERTY_USERNAME) && Strings.isNullOrEmpty(username)) {
+        collector.addFailure("Username is required for password grant type authentication.",
+                             "Please provide the Salesforce username.")
+          .withConfigProperty(SalesforceConstants.PROPERTY_USERNAME);
+      }
+      if (!containsMacro(SalesforceConstants.PROPERTY_PASSWORD) && Strings.isNullOrEmpty(password)) {
+        collector.addFailure("Password is required for password grant type authentication.",
+                             "Please provide the Salesforce password.")
+          .withConfigProperty(SalesforceConstants.PROPERTY_PASSWORD);
+      }
+      if (!containsMacro(SalesforceConstants.PROPERTY_SECURITY_TOKEN) && Strings.isNullOrEmpty(securityToken)) {
+        collector.addFailure("Security Token is required for password grant type authentication.",
+                             "Please provide the Salesforce security token.")
+          .withConfigProperty(SalesforceConstants.PROPERTY_SECURITY_TOKEN);
+      }
+    }
   }
 
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorInfo.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
 import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials.GrantType;
 import io.cdap.plugin.salesforce.plugin.connector.SalesforceConnectorConfig;
 
 import javax.annotation.Nullable;
@@ -103,6 +104,14 @@ public class SalesforceConnectorInfo {
     return config.isRetryOnBackendError();
   }
 
+  public GrantType getAuthenticationGrantType() {
+    return config.getAuthenticationGrantType();
+  }
+
+  public void validateAuthenticationFields(FailureCollector collector) {
+    config.validateAuthenticationFields(collector);
+  }
+
   public void validate(FailureCollector collector, @Nullable OAuthInfo oAuthInfo) {
     try {
       validateConnection(oAuthInfo);
@@ -149,6 +158,7 @@ public class SalesforceConnectorInfo {
 
     return !(config.containsMacro(SalesforceConstants.PROPERTY_CONSUMER_KEY)
       || config.containsMacro(SalesforceConstants.PROPERTY_CONSUMER_SECRET)
+      || config.containsMacro(SalesforceConstants.PROPERTY_AUTHENTICATION_GRANT_TYPE)
       || config.containsMacro(SalesforceConstants.PROPERTY_USERNAME)
       || config.containsMacro(SalesforceConstants.PROPERTY_PASSWORD)
       || config.containsMacro(SalesforceConstants.PROPERTY_LOGIN_URL)

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnectorConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/connector/SalesforceConnectorConfig.java
@@ -51,9 +51,10 @@ public class SalesforceConnectorConfig extends SalesforceConnectorBaseConfig {
                                    @Nullable Long initialRetryDuration,
                                    @Nullable Long maxRetryDuration,
                                    @Nullable Integer maxRetryCount,
-                                   @Nullable Boolean retryOnBackendError) {
+                                   @Nullable Boolean retryOnBackendError,
+                                   @Nullable String authenticationGrantType) {
     super(consumerKey, consumerSecret, username, password, loginUrl, securityToken, connectTimeout, readTimeout,
-          proxyUrl, initialRetryDuration, maxRetryDuration, maxRetryCount, retryOnBackendError);
+        proxyUrl, initialRetryDuration, maxRetryDuration, maxRetryCount, retryOnBackendError, authenticationGrantType);
     this.oAuthInfo = oAuthInfo;
   }
 

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceOutputFormatProvider.java
@@ -64,7 +64,8 @@ public class SalesforceOutputFormatProvider implements OutputFormatProvider {
       .put(SalesforceConstants.CONFIG_MAX_RETRY_COUNT,
            Integer.toString(config.getConnection().getMaxRetryCount()))
       .put(SalesforceConstants.CONFIG_RETRY_REQUIRED, Boolean.toString(config.getConnection()
-                                                                         .isRetryOnBackendError()));
+                                                                         .isRetryOnBackendError()))
+      .put(SalesforceConstants.CONFIG_GRANT_TYPE, config.getConnection().getAuthenticationGrantType().getType());
 
     if (!Strings.isNullOrEmpty(config.getConnection().getProxyUrl())) {
       configBuilder.put(SalesforceConstants.CONFIG_PROXY_URL, config.getConnection().getProxyUrl());
@@ -75,13 +76,15 @@ public class SalesforceOutputFormatProvider implements OutputFormatProvider {
         .put(SalesforceConstants.CONFIG_OAUTH_TOKEN, oAuthInfo.getAccessToken())
         .put(SalesforceConstants.CONFIG_OAUTH_INSTANCE_URL, oAuthInfo.getInstanceURL());
     } else {
-      configBuilder
-        .put(SalesforceConstants.CONFIG_USERNAME, Objects.requireNonNull(config.getConnection().getUsername()))
-        .put(SalesforceConstants.CONFIG_PASSWORD, Objects.requireNonNull(config.getConnection().getPassword()))
-        .put(SalesforceConstants.CONFIG_CONSUMER_KEY, Objects.requireNonNull(config.getConnection().getConsumerKey()))
-        .put(SalesforceConstants.CONFIG_CONSUMER_SECRET, Objects.requireNonNull(config.getConnection().
-                                                                                  getConsumerSecret()))
-        .put(SalesforceConstants.CONFIG_LOGIN_URL, Objects.requireNonNull(config.getConnection().getLoginUrl()));
+      configBuilder.put(SalesforceConstants.CONFIG_CONSUMER_KEY,
+                      Objects.requireNonNull(config.getConnection().getConsumerKey()))
+              .put(SalesforceConstants.CONFIG_CONSUMER_SECRET,
+                      Objects.requireNonNull(config.getConnection().getConsumerSecret()))
+              .put(SalesforceConstants.CONFIG_LOGIN_URL, Objects.requireNonNull(config.getConnection().getLoginUrl()));
+      if (config.getConnection().getAuthenticationGrantType() == AuthenticatorCredentials.GrantType.PASSWORD) {
+        configBuilder.put(SalesforceConstants.CONFIG_USERNAME, config.getConnection().getUsername())
+                .put(SalesforceConstants.CONFIG_PASSWORD, config.getConnection().getPassword());
+      }
     }
 
     if (config.getExternalIdField() != null) {

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/sink/batch/SalesforceSinkConfig.java
@@ -170,12 +170,13 @@ public class SalesforceSinkConfig extends ReferencePluginConfig {
                               @Nullable Long initialRetryDuration,
                               @Nullable Long maxRetryDuration,
                               @Nullable Integer maxRetryCount,
-                              @Nullable Boolean retryOnBackendError) {
+                              @Nullable Boolean retryOnBackendError,
+                              @Nullable String authenticationGrantType) {
     super(referenceName);
     connection = new SalesforceConnectorConfig(clientId, clientSecret, username, password, loginUrl,
                                                securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl,
                                                initialRetryDuration, maxRetryDuration, maxRetryCount,
-                                               retryOnBackendError);
+                                               retryOnBackendError, authenticationGrantType);
     this.sObject = sObject;
     this.operation = operation;
     this.externalIdField = externalIdField;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBaseSourceConfig.java
@@ -133,12 +133,13 @@ public abstract class SalesforceBaseSourceConfig extends ReferencePluginConfig {
                                        @Nullable Long maxRetryDuration,
                                        @Nullable Integer maxRetryCount,
                                        @Nullable Boolean retryOnBackendError,
-                                       @Nullable String proxyUrl) {
+                                       @Nullable String proxyUrl,
+                                       @Nullable String authenticationGrantType) {
     super(referenceName);
     this.connection = new SalesforceConnectorConfig(consumerKey, consumerSecret, username, password, loginUrl,
                                                     securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl,
                                                     initialRetryDuration, maxRetryDuration, maxRetryCount,
-                                                    retryOnBackendError);
+                                                    retryOnBackendError, authenticationGrantType);
     this.datetimeAfter = datetimeAfter;
     this.datetimeBefore = datetimeBefore;
     this.duration = duration;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceInputFormatProvider.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.plugin.salesforce.SalesforceConstants;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 
@@ -51,7 +52,8 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
            config.getConnection().getInitialRetryDuration().toString())
       .put(SalesforceConstants.CONFIG_MAX_RETRY_DURATION, config.getConnection().getMaxRetryDuration().toString())
       .put(SalesforceConstants.CONFIG_MAX_RETRY_COUNT, config.getConnection().getMaxRetryCount().toString())
-      .put(SalesforceConstants.CONFIG_RETRY_REQUIRED, config.getConnection().isRetryOnBackendError().toString());
+      .put(SalesforceConstants.CONFIG_RETRY_REQUIRED, config.getConnection().isRetryOnBackendError().toString())
+      .put(SalesforceConstants.CONFIG_GRANT_TYPE, config.getConnection().getAuthenticationGrantType().getType());
 
     if (!Strings.isNullOrEmpty(config.getConnection().getProxyUrl())) {
       configBuilder.put(SalesforceConstants.CONFIG_PROXY_URL, config.getConnection().getProxyUrl());
@@ -62,13 +64,15 @@ public class SalesforceInputFormatProvider implements InputFormatProvider {
         .put(SalesforceConstants.CONFIG_OAUTH_TOKEN, oAuthInfo.getAccessToken())
         .put(SalesforceConstants.CONFIG_OAUTH_INSTANCE_URL, oAuthInfo.getInstanceURL());
     } else {
-      configBuilder
-        .put(SalesforceConstants.CONFIG_USERNAME, Objects.requireNonNull(config.getConnection().getUsername()))
-        .put(SalesforceConstants.CONFIG_PASSWORD, Objects.requireNonNull(config.getConnection().getPassword()))
-        .put(SalesforceConstants.CONFIG_CONSUMER_KEY, Objects.requireNonNull(config.getConnection().getConsumerKey()))
-        .put(SalesforceConstants.CONFIG_CONSUMER_SECRET, Objects.requireNonNull(config.getConnection().
-                                                                                  getConsumerSecret()))
-        .put(SalesforceConstants.CONFIG_LOGIN_URL, Objects.requireNonNull(config.getConnection().getLoginUrl()));
+      configBuilder.put(SalesforceConstants.CONFIG_CONSUMER_KEY,
+                      Objects.requireNonNull(config.getConnection().getConsumerKey()))
+              .put(SalesforceConstants.CONFIG_CONSUMER_SECRET,
+                      Objects.requireNonNull(config.getConnection().getConsumerSecret()))
+              .put(SalesforceConstants.CONFIG_LOGIN_URL, Objects.requireNonNull(config.getConnection().getLoginUrl()));
+      if (config.getConnection().getAuthenticationGrantType() == AuthenticatorCredentials.GrantType.PASSWORD) {
+        configBuilder.put(SalesforceConstants.CONFIG_USERNAME, config.getConnection().getUsername())
+                .put(SalesforceConstants.CONFIG_PASSWORD, config.getConnection().getPassword());
+      }
     }
     if (sObjectNameField != null) {
       configBuilder.put(SalesforceSourceConstants.CONFIG_SOBJECT_NAME_FIELD, sObjectNameField);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfig.java
@@ -90,10 +90,11 @@ public class SalesforceMultiSourceConfig extends SalesforceBaseSourceConfig {
                                      @Nullable Long maxRetryDuration,
                                      @Nullable Integer maxRetryCount,
                                      Boolean retryOnBackendError,
-                                     @Nullable String proxyUrl) {
+                                     @Nullable String proxyUrl,
+                                     @Nullable String authenticationGrantType) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, connectTimeout, readTimeout,
           datetimeAfter, datetimeBefore, duration, offset, securityToken, oAuthInfo, operation, initialRetryDuration,
-          maxRetryDuration, maxRetryCount, retryOnBackendError, proxyUrl);
+          maxRetryDuration, maxRetryCount, retryOnBackendError, proxyUrl, authenticationGrantType);
     this.whiteList = whiteList;
     this.blackList = blackList;
     this.sObjectNameField = sObjectNameField;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfigBuilder.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceMultiSourceConfigBuilder.java
@@ -45,6 +45,7 @@ public class SalesforceMultiSourceConfigBuilder {
   private Integer readTimeout;
   private String proxyUrl;
   private Boolean retryOnBackendError;
+  private String authenticationGrantType;
 
   public SalesforceMultiSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -156,11 +157,20 @@ public class SalesforceMultiSourceConfigBuilder {
     return this;
   }
 
+  public String getAuthenticationGrantType() {
+    return authenticationGrantType;
+  }
+
+  public SalesforceMultiSourceConfigBuilder setAuthenticationGrantType(String authenticationGrantType) {
+    this.authenticationGrantType = authenticationGrantType;
+    return this;
+  }
+
   public SalesforceMultiSourceConfig build() {
     return new SalesforceMultiSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                            connectTimeout, readTimeout, datetimeAfter, datetimeBefore, duration,
                                            offset, whiteList, blackList, sObjectNameField, securityToken, oAuthInfo,
                                            operation, initialRetryDuration, maxRetryDuration, maxRetryCount,
-                                           retryOnBackendError, proxyUrl);
+                                           retryOnBackendError, proxyUrl, authenticationGrantType);
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -112,10 +112,11 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
                                 @Nullable Boolean enablePKChunk,
                                 @Nullable Integer chunkSize,
                                 @Nullable String parent,
-                                @Nullable String proxyUrl) {
+                                @Nullable String proxyUrl,
+                                @Nullable String authenticationGrantType) {
     super(referenceName, consumerKey, consumerSecret, username, password, loginUrl, connectTimeout, readTimeout,
       datetimeAfter, datetimeBefore, duration, offset, securityToken, oAuthInfo, operation, initialRetryDuration,
-      maxRetryDuration, maxRetryCount, retryOnBackendError, proxyUrl);
+      maxRetryDuration, maxRetryCount, retryOnBackendError, proxyUrl, authenticationGrantType);
     this.query = query;
     this.sObjectName = sObjectName;
     this.schema = schema;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigBuilder.java
@@ -45,6 +45,7 @@ public class SalesforceSourceConfigBuilder {
   private Integer readTimeout;
   private String proxyUrl;
   private Boolean retryOnBackendError;
+  private String authenticationGrantType;
 
   public SalesforceSourceConfigBuilder setReferenceName(String referenceName) {
     this.referenceName = referenceName;
@@ -166,11 +167,20 @@ public class SalesforceSourceConfigBuilder {
     return this;
   }
 
+  public String getAuthenticationGrantType() {
+    return authenticationGrantType;
+  }
+
+  public SalesforceSourceConfigBuilder setAuthenticationGrantType(String authenticationGrantType) {
+    this.authenticationGrantType = authenticationGrantType;
+    return this;
+  }
+
   public SalesforceSourceConfig build() {
     return new SalesforceSourceConfig(referenceName, consumerKey, consumerSecret, username, password, loginUrl,
                                       connectTimeout, readTimeout, query, sObjectName, datetimeAfter, datetimeBefore,
                                       duration, offset, schema, securityToken, operation, initialRetryDuration,
                                       maxRetryDuration, maxRetryCount, retryOnBackendError, null, enablePKChunk,
-                                      chunkSize, parent, proxyUrl);
+                                      chunkSize, parent, proxyUrl, authenticationGrantType);
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforceStreamingSourceConfig.java
@@ -153,14 +153,15 @@ public class SalesforceStreamingSourceConfig extends ReferencePluginConfig imple
                                          @Nullable Long initialRetryDuration,
                                          @Nullable Long maxRetryDuration,
                                          @Nullable Integer maxRetryCount,
-                                         @Nullable Boolean retryOnBackendError) {
+                                         @Nullable Boolean retryOnBackendError,
+                                         @Nullable String authenticationGrantType) {
     super(referenceName);
     this.pushTopicName = pushTopicName;
     this.sObjectName = sObjectName;
     this.connection = new SalesforceConnectorConfig(consumerKey, consumerSecret, username, password, loginUrl,
                                                     securityToken, connectTimeout, readTimeout, oAuthInfo, proxyUrl,
                                                     initialRetryDuration, maxRetryDuration, maxRetryCount,
-                                                    retryOnBackendError);
+                                                    retryOnBackendError, authenticationGrantType);
     this.schema = schema;
   }
 

--- a/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/BaseSalesforceBatchSinkETLTest.java
@@ -235,6 +235,6 @@ public abstract class BaseSalesforceBatchSinkETLTest extends BaseSalesforceETLTe
                                     Long.parseLong(INITIAL_RETRY_DURATION),
                                     Long.parseLong(MAX_RETRY_DURATION),
                                     Integer.parseInt(MAX_RETRY_COUNT),
-                                    Boolean.parseBoolean(RETRY_ON_BACKEND_ERROR));
+                                    Boolean.parseBoolean(RETRY_ON_BACKEND_ERROR), null);
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSinkSchemaValidation.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSinkSchemaValidation.java
@@ -68,7 +68,7 @@ public class SalesforceBatchSinkSchemaValidation {
                                "1000000", "10000",
                                "Fail on Error",
                                BaseSalesforceETLTest.SECURITY_TOKEN,
-                               null, null, true, 5L, 10L, 5, true));
+                               null, null, true, 5L, 10L, 5, true, null));
     Schema schema = Schema.recordOf("output",
                                     Schema.Field.of("Name", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("StageName", Schema.of(Schema.Type.STRING)),
@@ -138,7 +138,7 @@ public class SalesforceBatchSinkSchemaValidation {
                                "1000000", "10000",
                                "Fail on Error",
                                BaseSalesforceETLTest.SECURITY_TOKEN,
-                               null, null, true, 5L, 10L, 5, true));
+                               null, null, true, 5L, 10L, 5, true, null));
     Schema schema = Schema.recordOf("output",
                                     Schema.Field.of("Name", Schema.of(Schema.Type.STRING)));
     Field field = new Field();

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfigTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/SalesforceConnectorBaseConfigTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.salesforce.plugin;
+
+import io.cdap.cdap.etl.api.validation.CauseAttributes;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.salesforce.SalesforceConstants;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for {@link SalesforceConnectorBaseConfig#validateAuthenticationFields}.
+ */
+public class SalesforceConnectorBaseConfigTest {
+
+  private static final String VALID_CONSUMER_KEY = "testConsumerKey";
+  private static final String VALID_CONSUMER_SECRET = "testConsumerSecret";
+  private static final String VALID_USERNAME = "testUser";
+  private static final String VALID_PASSWORD = "testPassword";
+  private static final String VALID_SECURITY_TOKEN = "testToken";
+  private static final String VALID_LOGIN_URL = "https://login.salesforce.com/services/oauth2/token";
+
+  // --- PASSWORD grant type tests ---
+
+  @Test
+  public void testPasswordGrantAllFieldsValid() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, VALID_USERNAME, VALID_PASSWORD,
+      VALID_LOGIN_URL, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testPasswordGrantMissingConsumerKey() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      null, VALID_CONSUMER_SECRET, VALID_USERNAME, VALID_PASSWORD,
+      VALID_LOGIN_URL, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_CONSUMER_KEY,
+      "Consumer Key is required for authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantEmptyConsumerKey() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      "", VALID_CONSUMER_SECRET, VALID_USERNAME, VALID_PASSWORD,
+      VALID_LOGIN_URL, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_CONSUMER_KEY,
+      "Consumer Key is required for authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantMissingConsumerSecret() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, null, VALID_USERNAME, VALID_PASSWORD,
+      VALID_LOGIN_URL, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_CONSUMER_SECRET,
+      "Consumer Secret is required for authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantMissingLoginUrl() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, VALID_USERNAME, VALID_PASSWORD,
+      null, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_LOGIN_URL,
+      "Login URL is required for authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantMissingUsername() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, null, VALID_PASSWORD,
+      VALID_LOGIN_URL, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_USERNAME,
+      "Username is required for password grant type authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantMissingPassword() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, VALID_USERNAME, null,
+      VALID_LOGIN_URL, VALID_SECURITY_TOKEN, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_PASSWORD,
+      "Password is required for password grant type authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantMissingSecurityToken() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, VALID_USERNAME, VALID_PASSWORD,
+      VALID_LOGIN_URL, null, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_SECURITY_TOKEN,
+      "Security Token is required for password grant type authentication.");
+  }
+
+  @Test
+  public void testPasswordGrantMissingMultipleFields() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      null, null, null, null,
+      null, null, null, null, null, null, null, null, null, "password");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    List<String> failedFields = collector.getValidationFailures().stream()
+      .map(f -> f.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG))
+      .collect(Collectors.toList());
+    Assert.assertEquals(6, collector.getValidationFailures().size());
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_CONSUMER_KEY));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_CONSUMER_SECRET));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_LOGIN_URL));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_USERNAME));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_PASSWORD));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_SECURITY_TOKEN));
+  }
+
+  // --- CLIENT_CREDENTIALS grant type tests ---
+
+  @Test
+  public void testClientCredentialsGrantAllFieldsValid() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, null, null,
+      VALID_LOGIN_URL, null, null, null, null, null, null, null, null, "client_credentials");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testClientCredentialsGrantMissingConsumerKey() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      null, VALID_CONSUMER_SECRET, null, null,
+      VALID_LOGIN_URL, null, null, null, null, null, null, null, null, "client_credentials");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_CONSUMER_KEY,
+      "Consumer Key is required for authentication.");
+  }
+
+  @Test
+  public void testClientCredentialsGrantMissingConsumerSecret() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, null, null, null,
+      VALID_LOGIN_URL, null, null, null, null, null, null, null, null, "client_credentials");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_CONSUMER_SECRET,
+      "Consumer Secret is required for authentication.");
+  }
+
+  @Test
+  public void testClientCredentialsGrantMissingLoginUrl() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, null, null,
+      null, null, null, null, null, null, null, null, null, "client_credentials");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    assertSingleFailureOnField(collector, SalesforceConstants.PROPERTY_LOGIN_URL,
+      "Login URL is required for authentication.");
+  }
+
+  @Test
+  public void testClientCredentialsGrantDoesNotRequireUsername() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, null, null,
+      VALID_LOGIN_URL, null, null, null, null, null, null, null, null, "client_credentials");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    List<String> failedFields = collector.getValidationFailures().stream()
+      .map(f -> f.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG))
+      .collect(Collectors.toList());
+    Assert.assertFalse(failedFields.contains(SalesforceConstants.PROPERTY_USERNAME));
+    Assert.assertFalse(failedFields.contains(SalesforceConstants.PROPERTY_PASSWORD));
+    Assert.assertFalse(failedFields.contains(SalesforceConstants.PROPERTY_SECURITY_TOKEN));
+  }
+
+  @Test
+  public void testClientCredentialsGrantMissingMultipleFields() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      null, null, null, null,
+      null, null, null, null, null, null, null, null, null, "client_credentials");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    List<String> failedFields = collector.getValidationFailures().stream()
+      .map(f -> f.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG))
+      .collect(Collectors.toList());
+    Assert.assertEquals(3, collector.getValidationFailures().size());
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_CONSUMER_KEY));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_CONSUMER_SECRET));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_LOGIN_URL));
+  }
+
+  // --- Default grant type (null defaults to PASSWORD) ---
+
+  @Test
+  public void testDefaultGrantTypeIsPassword() {
+    SalesforceConnectorBaseConfig config = new SalesforceConnectorBaseConfig(
+      VALID_CONSUMER_KEY, VALID_CONSUMER_SECRET, null, null,
+      VALID_LOGIN_URL, null, null, null, null, null, null, null, null, null);
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateAuthenticationFields(collector);
+    List<String> failedFields = collector.getValidationFailures().stream()
+      .map(f -> f.getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG))
+      .collect(Collectors.toList());
+    // null grant type defaults to PASSWORD, so username/password/securityToken should be required
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_USERNAME));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_PASSWORD));
+    Assert.assertTrue(failedFields.contains(SalesforceConstants.PROPERTY_SECURITY_TOKEN));
+  }
+
+  private void assertSingleFailureOnField(MockFailureCollector collector, String expectedField,
+                                           String expectedMessage) {
+    List<ValidationFailure> failures = collector.getValidationFailures();
+    Assert.assertEquals(1, failures.size());
+    Assert.assertEquals(expectedField,
+      failures.get(0).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+    Assert.assertEquals(expectedMessage, failures.get(0).getMessage());
+  }
+}

--- a/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfigTest.java
@@ -287,7 +287,7 @@ public class SalesforceSourceConfigTest {
                                                                         Mockito.any(), Mockito.any(), Mockito.any(),
                                                                         Mockito.anyString(), Mockito.anyLong(),
                                                                         Mockito.anyLong(), Mockito.anyInt(),
-                                                                        Mockito.anyBoolean())
+                                                                        Mockito.anyBoolean(), Mockito.anyString())
       .thenReturn(connectorConfig);
     SalesforceConnectorInfo salesforceConnectorInfo =
       new SalesforceConnectorInfo(null, connectorConfig,

--- a/widgets/Salesforce-batchsink.json
+++ b/widgets/Salesforce-batchsink.json
@@ -46,6 +46,25 @@
           "name": "oAuthInfo"
         },
         {
+          "name": "authenticationGrantType",
+          "label": "OAuth Grant Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "password",
+            "options": [
+              {
+                "id": "password",
+                "label": "Password"
+              },
+              {
+                "id": "client_credentials",
+                "label": "Client Credentials"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "username"
@@ -266,6 +285,26 @@
     }
   ],
   "filters": [
+    {
+      "name": "GrantTypePassword",
+      "condition": {
+        "expression": "authenticationGrantType != 'client_credentials'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "username"
+        },
+        {
+          "type": "property",
+          "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "securityToken"
+        }
+      ]
+    },
     {
       "name": "showConnectionProperties ",
       "condition": {

--- a/widgets/Salesforce-batchsource.json
+++ b/widgets/Salesforce-batchsource.json
@@ -46,6 +46,25 @@
           "name": "oAuthInfo"
         },
         {
+          "name": "authenticationGrantType",
+          "label": "OAuth Grant Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "password",
+            "options": [
+              {
+                "id": "password",
+                "label": "Password"
+              },
+              {
+                "id": "client_credentials",
+                "label": "Client Credentials"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "username"
@@ -307,6 +326,26 @@
     }
   ],
   "filters":[
+    {
+      "name": "GrantTypePassword",
+      "condition": {
+        "expression": "authenticationGrantType != 'client_credentials'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "username"
+        },
+        {
+          "type": "property",
+          "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "securityToken"
+        }
+      ]
+    },
     {
       "name": "enablePKChunk",
       "condition": {

--- a/widgets/Salesforce-connector.json
+++ b/widgets/Salesforce-connector.json
@@ -13,6 +13,25 @@
           "name": "oAuthInfo"
         },
         {
+          "name": "authenticationGrantType",
+          "label": "OAuth Grant Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "password",
+            "options": [
+              {
+                "id": "password",
+                "label": "Password"
+              },
+              {
+                "id": "client_credentials",
+                "label": "Client Credentials"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "User Name",
           "name": "username",
@@ -138,5 +157,26 @@
     }
   ],
   "outputs": [],
-  "filters": []
+  "filters":[
+    {
+      "name": "GrantTypePassword",
+      "condition": {
+        "expression": "authenticationGrantType != 'client_credentials'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "username"
+        },
+        {
+          "type": "property",
+          "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "securityToken"
+        }
+      ]
+    }
+  ]
 }

--- a/widgets/Salesforce-streamingsource.json
+++ b/widgets/Salesforce-streamingsource.json
@@ -46,6 +46,25 @@
           "name": "oAuthInfo"
         },
         {
+          "name": "authenticationGrantType",
+          "label": "OAuth Grant Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "password",
+            "options": [
+              {
+                "id": "password",
+                "label": "Password"
+              },
+              {
+                "id": "client_credentials",
+                "label": "Client Credentials"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "username"
@@ -240,7 +259,28 @@
       ]
     }
   ],
-  "filters": [],
+  "filters":[
+    {
+      "name": "GrantTypePassword",
+      "condition": {
+        "expression": "authenticationGrantType != 'client_credentials'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "username"
+        },
+        {
+          "type": "property",
+          "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "securityToken"
+        }
+      ]
+    }
+  ],
   "outputs": [
     {
       "name": "schema",

--- a/widgets/SalesforceMultiObjects-batchsource.json
+++ b/widgets/SalesforceMultiObjects-batchsource.json
@@ -46,6 +46,25 @@
           "name": "oAuthInfo"
         },
         {
+          "name": "authenticationGrantType",
+          "label": "OAuth Grant Type",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "password",
+            "options": [
+              {
+                "id": "password",
+                "label": "Password"
+              },
+              {
+                "id": "client_credentials",
+                "label": "Client Credentials"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Username",
           "name": "username"
@@ -270,6 +289,26 @@
     }
   ],
   "filters": [
+    {
+      "name": "GrantTypePassword",
+      "condition": {
+        "expression": "authenticationGrantType != 'client_credentials'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "username"
+        },
+        {
+          "type": "property",
+          "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "securityToken"
+        }
+      ]
+    },
     {
       "name": "showConnectionProperties ",
       "condition": {


### PR DESCRIPTION
# Support for client credentials Grant type

Jira : [PLUGIN-1953](https://cdap.atlassian.net/browse/PLUGIN-1953)

## Summary

Adds support for the **Client Credentials** OAuth grant type to all Salesforce plugins (source, sink, streaming, connector).

## Files updated

### Widgets (UI)
Expose the **OAuth Grant Type** radio group and add a filter that hides `username` / `password` / `securityToken` when `client_credentials` is selected.
- `widgets/Salesforce-connector.json`
- `widgets/Salesforce-batchsink.json`
- `widgets/Salesforce-batchsource.json`
- `widgets/Salesforce-streamingsource.json`
- `widgets/SalesforceMultiObjects-batchsource.json`

### Docs
Document the new **Grant Type** field, clarify which fields are required per grant type, and note that `client_credentials` requires an instance-specific login URL.
- `docs/Salesforce-connector.md`
- `docs/Salesforce-batchsink.md`
- `docs/Salesforce-batchsource.md`
- `docs/Salesforce-streamingsource.md`
- `docs/SalesforceMultiObjects-batchsource.md`

## What's new

**New config property `authenticationGrantType`** backed by the pre-existing `AuthenticatorCredentials.GrantType` enum (`password` / `client_credentials`). Null is treated as `password` so upgraded pipelines that were saved before this change keep working without manual edits.

### Validation
New `validateAuthenticationFields(FailureCollector)` on `SalesforceConnectorBaseConfig`:
- Always required: `consumerKey`, `consumerSecret`, `loginUrl`.
- Only required for `password`: `username`, `password`, `securityToken`.
- Macro-aware skips any field whose value is a macro, and skips entirely if the grant type itself is a macro.
- Each missing field reports its own failure tied to its `withConfigProperty(...)`, so the UI highlights the exact field.

### UI changes
- New **OAuth Grant Type** radio group (inline layout, defaults to `password`) added to all five widget JSONs.
- A `GrantTypePassword` filter hides `username` / `password` / `securityToken` when `client_credentials` is selected, so users only see the fields they need to fill in.

### Screenshots


- Radio [Password]
<img width="2312" height="1256" alt="image" src="https://github.com/user-attachments/assets/74ff204d-6d19-4f1f-81ed-70f25ff00c9e" />


- Radio [Client Credentials]
<img width="2312" height="838" alt="image" src="https://github.com/user-attachments/assets/b34a8e1b-c507-45bc-9c70-df562c23e0e6" />

- Missing value validation
<img width="2312" height="876" alt="image" src="https://github.com/user-attachments/assets/9fd8e4de-0c26-4317-b7e6-809feda8f74f" />


## Tests added

New file: **`SalesforceConnectorBaseConfigTest.java`** (250 lines) covering `validateAuthenticationFields()`:

- **Password grant** happy path + one test per missing field (`consumerKey`, `consumerSecret`, `loginUrl`, `username`, `password`, `securityToken`), including empty-string handling, plus an all-missing test that asserts exactly 6 failures on the right fields.
- **Client Credentials grant** happy path, missing `consumerKey` / `consumerSecret` / `loginUrl`, explicit assertion that `username` / `password` / `securityToken` are *not* flagged, and an all-missing test that asserts exactly 3 failures.
- **Default behavior**  null `authenticationGrantType` falls back to `PASSWORD` validation rules.

## Additional notes for reviewer

- **Backward compatibility:** existing pipelines persisted without `authenticationGrantType` will deserialize with a null value, which `getAuthenticationGrantType()` maps to `PASSWORD`.

- **Login URL gotcha:** `client_credentials` requires an instance-specific URL (e.g. `https://<instance>.my.salesforce.com/services/oauth2/token`) rather than the generic `login.salesforce.com` endpoint. This is called out in the updated docs.


[PLUGIN-1953]: https://cdap.atlassian.net/browse/PLUGIN-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ