### PR TITLE
[PLUGIN-1957] Validate PK Chunking for incremental loads

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceQueryUtil.java
@@ -15,8 +15,22 @@
  */
 package io.cdap.plugin.salesforce;
 
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import io.cdap.plugin.salesforce.authenticator.Authenticator;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
+import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -84,6 +98,18 @@ public class SalesforceQueryUtil {
   }
 
   /**
+   * Creates a COUNT query from an existing SOQL query.
+   * Replaces the SELECT fields with COUNT() while preserving the FROM and WHERE clauses.
+   *
+   * @param query the original SOQL query
+   * @return a COUNT SOQL query string
+   */
+  public static String createCountQuery(String query) {
+    String fromStatement = SalesforceQueryParser.getFromStatement(query);
+    return SELECT + "COUNT() " + fromStatement;
+  }
+
+  /**
    * Generates SObject query filter based on provided values.
    *
    * @param filterDescriptor filter options holder
@@ -105,5 +131,86 @@ public class SalesforceQueryUtil {
         .append(filterDescriptor.getEndTime().format(DateTimeFormatter.ISO_DATE_TIME));
     }
     return filter.toString();
+  }
+
+  /**
+   * Fetches query plan from Salesforce query explain REST API.
+   *
+   * @param query SOQL query
+   * @param credentials credentials to authenticate the call
+   * @return query plan details
+   * @throws Exception in case of network or API failures
+   */
+  public static QueryPlanResponse getQueryPlan(
+      final String query,
+      final AuthenticatorCredentials credentials)
+      throws Exception {
+    OAuthInfo oAuthInfo = Authenticator.getOAuthInfo(credentials);
+    String explainUrl = String.format(
+        "%s/services/data/v%s/query/?explain=%s",
+        oAuthInfo.getInstanceURL(),
+        SalesforceConstants.API_VERSION,
+        URLEncoder.encode(query, "UTF-8"));
+
+    SslContextFactory sslContextFactory = new SslContextFactory();
+    HttpClient httpClient = new HttpClient(sslContextFactory);
+    httpClient.setConnectTimeout(credentials.getConnectTimeout());
+    if (!Strings.isNullOrEmpty(credentials.getProxyUrl())) {
+      Authenticator.setProxy(credentials, httpClient);
+    }
+
+    try {
+      httpClient.start();
+      Request request = httpClient.newRequest(explainUrl)
+          .method(HttpMethod.GET)
+          .header(
+              HttpHeader.AUTHORIZATION,
+              "Bearer " + oAuthInfo.getAccessToken())
+          .header(
+              HttpHeader.CONTENT_TYPE,
+              "application/json");
+      ContentResponse response = request.send();
+      String responseContent = response.getContentAsString();
+      if (response.getStatus() != HttpURLConnection.HTTP_OK) {
+        throw new IOException(String.format(
+            "Failed to get Query Plan. Status='%s', Response='%s'",
+            response.getStatus(), responseContent));
+      }
+      return new Gson().fromJson(responseContent, QueryPlanResponse.class);
+    } finally {
+      httpClient.stop();
+    }
+  }
+
+  /**
+   * Holds query plan response from Salesforce REST API.
+   */
+  public static class QueryPlanResponse {
+    private List<QueryPlan> plans;
+
+    public List<QueryPlan> getPlans() {
+      return plans;
+    }
+  }
+
+  /**
+   * Holds single query plan details.
+   */
+  public static class QueryPlan {
+    private double relativeCost;
+    private long cardinality;
+    private String leadingOperationType;
+
+    public double getRelativeCost() {
+      return relativeCost;
+    }
+
+    public long getCardinality() {
+      return cardinality;
+    }
+
+    public String getLeadingOperationType() {
+      return leadingOperationType;
+    }
   }
 }

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceBatchSource.java
@@ -48,6 +48,8 @@ import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.BulkConnectionRetryWrapper;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSourceConstants;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -71,6 +73,7 @@ public class SalesforceBatchSource extends
   public static final String NAME = "Salesforce";
 
   private final SalesforceSourceConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(SalesforceBatchSource.class);
   private Schema schema;
   private MapToRecordTransformer transformer;
   private Set<String> jobIds = new HashSet<>();
@@ -139,7 +142,7 @@ public class SalesforceBatchSource extends
 
     authenticatorCredentials = config.getConnection().getAuthenticatorCredentials();
     List<SalesforceSplit> querySplits =
-        getSplits(config, authenticatorCredentials, context.getLogicalStartTime(), oAuthInfo);
+        getSplits(config, authenticatorCredentials, context.getLogicalStartTime(), oAuthInfo, false);
     querySplits.stream().forEach(salesforceSplit -> jobIds.add(salesforceSplit.getJobId()));
     context.setInput(Input.of(config.getReferenceNameOrNormalizedFQN(orgId, sObjectName),
         new SalesforceInputFormatProvider(
@@ -148,10 +151,22 @@ public class SalesforceBatchSource extends
 
   public static List<SalesforceSplit> getSplits(
       SalesforceSourceConfig config, AuthenticatorCredentials authenticatorCredentials,
-      long logicStartTime, OAuthInfo oAuthInfo) {
+      long logicStartTime, OAuthInfo oAuthInfo, boolean pkChunkCountCheck) {
     String query = config.getQuery(logicStartTime, oAuthInfo);
     BulkConnection bulkConnection = SalesforceSplitUtil.getBulkConnection(authenticatorCredentials);
+
     boolean enablePKChunk = config.getEnablePKChunk();
+
+    if (enablePKChunk && pkChunkCountCheck) {
+      enablePKChunk = SalesforceSplitUtil.hasRequiredCountForPkChunking(
+          query, authenticatorCredentials, config.getChunkSize());
+      if (!enablePKChunk) {
+        LOG.info(
+            "PK chunking skipped: record count is below threshold {} ",
+                config.getChunkSize());
+      }
+    }
+
     if (enablePKChunk) {
       String parent = config.getParent();
       int chunkSize = config.getChunkSize();

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/util/SalesforceSplitUtil.java
@@ -26,6 +26,8 @@ import com.sforce.async.ContentType;
 import com.sforce.async.JobInfo;
 import com.sforce.async.JobStateEnum;
 import com.sforce.async.OperationEnum;
+import com.sforce.soap.partner.PartnerConnection;
+import com.sforce.soap.partner.QueryResult;
 import dev.failsafe.FailsafeException;
 import dev.failsafe.RetryPolicy;
 import dev.failsafe.TimeoutExceededException;
@@ -33,9 +35,13 @@ import io.cdap.plugin.salesforce.BulkAPIBatchException;
 import io.cdap.plugin.salesforce.InvalidConfigException;
 import io.cdap.plugin.salesforce.SObjectDescriptor;
 import io.cdap.plugin.salesforce.SalesforceBulkUtil;
+import io.cdap.plugin.salesforce.SalesforceConnectionUtil;
+import io.cdap.plugin.salesforce.SalesforceConstants;
 import io.cdap.plugin.salesforce.SalesforceQueryUtil;
 import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
+import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.source.batch.SalesforceSplit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -263,8 +269,76 @@ public final class SalesforceSplitUtil {
     return false;
   }
 
-  // This is added only for UCS use case.
-  private static boolean isCustomObject(String sobjectName) {
+  /**
+   * Determines whether PK chunking should be enabled or disabled based on the
+   * estimated record count, object support, and query compatibility.
+   *
+   * @param query       the SOQL query
+   * @param credentials authenticator credentials for SOAP API
+   * @param threshold   the record count threshold for enabling PK chunking
+   * @return true if PK chunking should be enabled, false otherwise
+   */
+  public static boolean hasRequiredCountForPkChunking(
+      final String query,
+      final AuthenticatorCredentials credentials,
+      final long threshold) {
+    try {
+      String sObjectName = SObjectDescriptor.fromQuery(query).getName();
+      String countQuery = SalesforceQueryUtil.createCountQuery(query);
+
+      try {
+        SalesforceQueryUtil.QueryPlanResponse planResponse =
+            SalesforceQueryUtil.getQueryPlan(countQuery, credentials);
+        if (planResponse != null && planResponse.getPlans() != null
+            && !planResponse.getPlans().isEmpty()) {
+          SalesforceQueryUtil.QueryPlan leadingPlan =
+              planResponse.getPlans().get(0);
+          LOG.debug(
+              "PK Chunking Query Plan: leading operation is '{}', "
+                  + "cardinality is {}, cost is {}",
+              leadingPlan.getLeadingOperationType(),
+              leadingPlan.getCardinality(),
+              leadingPlan.getRelativeCost());
+          if (leadingPlan.getCardinality() >= threshold
+              || leadingPlan.getRelativeCost() >= 1.0) {
+            LOG.info(
+                "PK Chunking: Query Plan indicates high volume or "
+                    + "non-selective scan. Auto-enabling PK Chunking.");
+            return true;
+          }
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "PK Chunking: Query Plan check failed, defaulting to true.",
+            e);
+        return true;
+      }
+
+      PartnerConnection partnerConnection =
+          SalesforceConnectionUtil.getPartnerConnection(credentials);
+      QueryResult result = partnerConnection.query(countQuery);
+      int recordCount = result.getSize();
+      LOG.debug(
+          "PK Chunking validation: object '{}' has {} records, "
+              + "threshold is {}",
+          sObjectName, recordCount, threshold);
+      return recordCount >= threshold;
+    } catch (Exception e) {
+      LOG.warn(
+          "PK Chunking validation: unexpected error during COUNT() query "
+              + "check, falling back to default PK chunking",
+          e);
+      return true;
+    }
+  }
+
+  /**
+   * Helper method to check if sobject is custom object.
+   *
+   * @param sobjectName name of the sobject
+   * @return true if custom, false otherwise
+   */
+  private static boolean isCustomObject(final String sobjectName) {
     return sobjectName.toLowerCase().endsWith("__c");
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceQueryUtilTest.java
@@ -16,9 +16,25 @@
 package io.cdap.plugin.salesforce;
 
 import com.google.common.collect.ImmutableMap;
+import io.cdap.plugin.salesforce.authenticator.Authenticator;
+import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
+import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.net.HttpURLConnection;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -32,6 +48,15 @@ import java.util.stream.IntStream;
 /**
  * Tests for {@link SalesforceQueryUtil}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+    SalesforceConnectionUtil.class,
+    Authenticator.class,
+    SalesforceQueryUtil.class,
+    OAuthInfo.class,
+    HttpClient.class,
+    org.eclipse.jetty.util.component.AbstractLifeCycle.class
+})
 public class SalesforceQueryUtilTest {
 
   @Test
@@ -226,5 +251,110 @@ public class SalesforceQueryUtilTest {
     String sObjectIdQuery = SalesforceQueryUtil.createSObjectIdQuery(query);
 
     Assert.assertEquals("SELECT Id " + fromClause, sObjectIdQuery);
+  }
+
+  @Test
+  public void createCountQuery_withWhereClause_replacesSelectFieldsWithCount() {
+    String query = "SELECT Id,Name,SomeField FROM sObjectName WHERE LastModifiedDate>=2019-04-12T23:23:23Z";
+
+    String result = SalesforceQueryUtil.createCountQuery(query);
+
+    Assert.assertEquals(
+      "SELECT COUNT() FROM sObjectName WHERE LastModifiedDate>=2019-04-12T23:23:23Z",
+      result);
+  }
+
+  @Test
+  public void createCountQuery_withoutWhereClause_replacesSelectFieldsWithCount() {
+    String query = "SELECT Id, Name FROM Account";
+
+    String result = SalesforceQueryUtil.createCountQuery(query);
+
+    Assert.assertEquals("SELECT COUNT() FROM Account", result);
+  }
+
+  @Test(expected = Exception.class)
+  public void getQueryPlan_whenRestClientConnectionFails_throwsException() throws Exception {
+    String query = "SELECT Name FROM Account";
+    AuthenticatorCredentials credentials = Mockito.mock(AuthenticatorCredentials.class);
+    Mockito.when(credentials.getConnectTimeout()).thenReturn(3000);
+    PowerMockito.mockStatic(SalesforceConnectionUtil.class);
+    PowerMockito.when(SalesforceConnectionUtil.getPartnerConnection(credentials))
+        .thenThrow(new RuntimeException("REST Client Connection Failure"));
+
+    SalesforceQueryUtil.getQueryPlan(query, credentials);
+  }
+
+  @Test
+  public void getQueryPlan_success_returnsQueryPlanResponse() throws Exception {
+    String query = "SELECT COUNT() FROM Account";
+    AuthenticatorCredentials credentials = Mockito.mock(AuthenticatorCredentials.class);
+    Mockito.when(credentials.getConnectTimeout()).thenReturn(3000);
+    OAuthInfo oAuthInfo = PowerMockito.mock(OAuthInfo.class);
+    Mockito.when(oAuthInfo.getInstanceURL()).thenReturn("https://instance.salesforce.com");
+    Mockito.when(oAuthInfo.getAccessToken()).thenReturn("test-token");
+    PowerMockito.mockStatic(Authenticator.class);
+    PowerMockito.when(Authenticator.getOAuthInfo(credentials)).thenReturn(oAuthInfo);
+    HttpClient httpClient = PowerMockito.mock(HttpClient.class);
+    PowerMockito.whenNew(HttpClient.class).withArguments(Mockito.any(SslContextFactory.class))
+        .thenReturn(httpClient);
+    Request request = Mockito.mock(Request.class);
+    Mockito.when(httpClient.newRequest(Mockito.anyString())).thenReturn(request);
+    Mockito.when(request.method(Mockito.any(HttpMethod.class))).thenReturn(request);
+    Mockito.when(request.header(Mockito.any(HttpHeader.class), Mockito.anyString()))
+        .thenReturn(request);
+    ContentResponse response = Mockito.mock(ContentResponse.class);
+    Mockito.when(request.send()).thenReturn(response);
+    Mockito.when(response.getStatus()).thenReturn(HttpURLConnection.HTTP_OK);
+    Mockito.when(response.getContentAsString())
+        .thenReturn("{\"plans\":[{\"relativeCost\":0.5,\"cardinality\":12345,\"leadingOperationType\":\"Index\"}]}");
+
+    SalesforceQueryUtil.QueryPlanResponse result = SalesforceQueryUtil.getQueryPlan(query, credentials);
+
+    Assert.assertNotNull(result);
+    Assert.assertEquals(1, result.getPlans().size());
+    Assert.assertEquals(0.5, result.getPlans().get(0).getRelativeCost(), 0.0001);
+    Assert.assertEquals(12345, result.getPlans().get(0).getCardinality());
+    Assert.assertEquals("Index", result.getPlans().get(0).getLeadingOperationType());
+  }
+
+  @Test
+  public void hasRequiredCountForPkChunking_queryPlanFails_defaultsToTrue() throws Exception {
+    String query = "SELECT Id, Name FROM Opportunity";
+    AuthenticatorCredentials credentials = Mockito.mock(AuthenticatorCredentials.class);
+    long threshold = 100000;
+    PowerMockito.mockStatic(SalesforceQueryUtil.class);
+    PowerMockito.when(SalesforceQueryUtil.createCountQuery(query))
+        .thenReturn("SELECT COUNT() FROM Opportunity");
+    PowerMockito.when(SalesforceQueryUtil.getQueryPlan(Mockito.anyString(), Mockito.any()))
+        .thenThrow(new RuntimeException("Query plan API error"));
+
+    boolean result = SalesforceSplitUtil.hasRequiredCountForPkChunking(query, credentials, threshold);
+
+    Assert.assertTrue(result);
+  }
+
+  @Test
+  public void hasRequiredCountForPkChunking_countQueryFails_defaultsToTrue() throws Exception {
+    String query = "SELECT Id, Name FROM Opportunity";
+    AuthenticatorCredentials credentials = Mockito.mock(AuthenticatorCredentials.class);
+    long threshold = 100000;
+    PowerMockito.mockStatic(SalesforceQueryUtil.class);
+    PowerMockito.when(SalesforceQueryUtil.createCountQuery(query))
+        .thenReturn("SELECT COUNT() FROM Opportunity");
+    SalesforceQueryUtil.QueryPlanResponse planResponse = Mockito.mock(SalesforceQueryUtil.QueryPlanResponse.class);
+    SalesforceQueryUtil.QueryPlan plan = Mockito.mock(SalesforceQueryUtil.QueryPlan.class);
+    Mockito.when(plan.getCardinality()).thenReturn(10L);
+    Mockito.when(plan.getRelativeCost()).thenReturn(0.1);
+    Mockito.when(planResponse.getPlans()).thenReturn(Collections.singletonList(plan));
+    PowerMockito.when(SalesforceQueryUtil.getQueryPlan(Mockito.anyString(), Mockito.any()))
+        .thenReturn(planResponse);
+    PowerMockito.mockStatic(SalesforceConnectionUtil.class);
+    PowerMockito.when(SalesforceConnectionUtil.getPartnerConnection(credentials))
+        .thenThrow(new RuntimeException("Partner connection count query error"));
+
+    boolean result = SalesforceSplitUtil.hasRequiredCountForPkChunking(query, credentials, threshold);
+
+    Assert.assertTrue(result);
   }
 }

--- a/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/etl/SalesforceBatchSourceETLTest.java
@@ -624,4 +624,108 @@ public class SalesforceBatchSourceETLTest extends BaseSalesforceBatchSourceETLTe
     Assert.assertEquals("record3", results.get(2).get("Name"));
     Assert.assertEquals("record4", results.get(3).get("Name"));
   }
+
+  @Test
+  public void getSplits_pkChunkEnabledWithCustomChunkSize_returnsAllRecords() throws Exception {
+    ImmutableMap<String, String> properties = new ImmutableMap.Builder<String, String>()
+        .put("enablePKChunk", "true")
+        .put("chunkSize", "2")
+        .build();
+
+    testPKChunk(properties);
+  }
+
+  @Test
+  public void getSplits_pkChunkEnabledWithDefaultChunkSize_returnsAllRecords() throws Exception {
+    ImmutableMap<String, String> properties = new ImmutableMap.Builder<String, String>()
+        .put("enablePKChunk", "true")
+        .build();
+
+    testPKChunk(properties);
+  }
+
+  @Test
+  public void getSplits_pkChunkEnabledWithRecordsBelowThreshold_chunkingSkipped() throws Exception {
+    String sObjectName = createCustomObject("IT_PKChunkBelowThreshold", null);
+    List<SObject> sObjects = new ImmutableList.Builder<SObject>()
+        .add(new SObjectBuilder()
+            .setType(sObjectName)
+            .put("Name", "record1")
+            .build())
+        .add(new SObjectBuilder()
+            .setType(sObjectName)
+            .put("Name", "record2")
+            .build())
+        .build();
+    addSObjects(sObjects, true);
+    ImmutableMap.Builder<String, String> properties =
+        getBaseProperties("SalesforceReaderPKChunkBelowThreshold");
+    properties.put("enablePKChunk", "true");
+    properties.put(SalesforceSourceConstants.PROPERTY_QUERY, "SELECT Name FROM " + sObjectName);
+
+    List<StructuredRecord> results = getPipelineResults(
+        properties.build(), SalesforceBatchSource.NAME, "SalesforceBatch");
+    results.sort(Comparator.comparing(record -> record.get("Name")));
+
+    Assert.assertEquals(2, results.size());
+    Assert.assertEquals("record1", results.get(0).get("Name"));
+    Assert.assertEquals("record2", results.get(1).get("Name"));
+  }
+
+  @Test
+  public void getSplits_pkChunkDisabled_chunkingNotApplied() throws Exception {
+    String sObjectName = createCustomObject("IT_PKChunkDisabled", null);
+    List<SObject> sObjects = new ImmutableList.Builder<SObject>()
+        .add(new SObjectBuilder()
+            .setType(sObjectName)
+            .put("Name", "record1")
+            .build())
+        .add(new SObjectBuilder()
+            .setType(sObjectName)
+            .put("Name", "record2")
+            .build())
+        .build();
+    addSObjects(sObjects, true);
+    ImmutableMap.Builder<String, String> properties =
+        getBaseProperties("SalesforceReaderPKChunkDisabled");
+    properties.put("enablePKChunk", "false");
+    properties.put(SalesforceSourceConstants.PROPERTY_QUERY, "SELECT Name FROM " + sObjectName);
+
+    List<StructuredRecord> results = getPipelineResults(
+        properties.build(), SalesforceBatchSource.NAME, "SalesforceBatch");
+    results.sort(Comparator.comparing(record -> record.get("Name")));
+
+    Assert.assertEquals(2, results.size());
+    Assert.assertEquals("record1", results.get(0).get("Name"));
+    Assert.assertEquals("record2", results.get(1).get("Name"));
+  }
+
+  @Test
+  public void getSplits_pkChunkEnabledOnCustomObjectBelowThreshold_chunkingSkipped() throws Exception {
+    String customObjectName = createCustomObject("IT_CustomPKChunk", null);
+    List<SObject> sObjects = new ImmutableList.Builder<SObject>()
+        .add(new SObjectBuilder()
+            .setType(customObjectName)
+            .put("Name", "custom_record1")
+            .build())
+        .add(new SObjectBuilder()
+            .setType(customObjectName)
+            .put("Name", "custom_record2")
+            .build())
+        .build();
+    addSObjects(sObjects, true);
+    ImmutableMap.Builder<String, String> properties =
+        getBaseProperties("SalesforceReaderCustomPKChunk");
+    properties.put("enablePKChunk", "true");
+    properties.put("chunkSize", "100000");
+    properties.put(SalesforceSourceConstants.PROPERTY_QUERY, "SELECT Name FROM " + customObjectName);
+
+    List<StructuredRecord> results = getPipelineResults(
+        properties.build(), SalesforceBatchSource.NAME, "SalesforceBatch");
+    results.sort(Comparator.comparing(record -> record.get("Name")));
+
+    Assert.assertEquals(2, results.size());
+    Assert.assertEquals("custom_record1", results.get(0).get("Name"));
+    Assert.assertEquals("custom_record2", results.get(1).get("Name"));
+  }
 }


### PR DESCRIPTION
# [PLUGIN-1957] Autodetect PK Chunking for incremental loads

## What

Adds an autonomous pre-flight check to decide whether to enable PK Chunking in `SalesforceBatchSource.getSplits()`.
*   If the estimated record count is below the user-configured chunk size (`config.getChunkSize()`) and the query is selective, PK chunking is skipped and executed as a standard un-chunked query to avoid "empty chunk" overhead on small datasets.
*   If the dataset volume exceeds the threshold, or is flagged as non-selective, PK Chunking is enabled.
*   This feature is specifically designed for automated Data Transfer Service.

## Why

PK chunking is designed for very large datasets. Enabling it on small datasets (like highly restrictive incremental intervals where 0 or very few records changed) causes dozens of empty chunk boundaries to be spooled and executed, wasting daily Bulk API allocations and adding massive pipeline overhead. This change ensures chunking is only applied when operationally justified by the actual matching record volume.

## Changes

*   **`SalesforceBatchSource.java`**: Configured PK chunking threshold dynamically using `chunkSize`.
*   **`SalesforceSplitUtil.java`**: Added REST Query Plan explain check and removed unused constants.
*   **`SalesforceQueryUtil.java`**: Replaced magic HTTP status codes with constants.
*   **`SalesforceSourceConstants.java`**: Cleaned up the unused threshold constant.
*   **`SalesforceQueryUtilTest.java`**: Added unit tests covering Query Plan and fallback paths.
*   **`SalesforceBatchSourceETLTest.java`**: Renamed ETL test case to remove UI naming.

---

[PLUGIN-1957]: https://cdap.atlassian.net/browse/PLUGIN-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
