### PR TITLE
[🍒]fix: remove error stack trace from validation failures

### DIFF
--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceConnectionUtil.java
@@ -130,8 +130,7 @@ public class SalesforceConnectionUtil {
     } catch (Exception e) {
       String message = getSalesforceErrorMessageFromException(e);
       collector.addFailure("Error encountered while establishing connection: " + message,
-                           "Please verify authentication properties are provided correctly")
-        .withStacktrace(e.getStackTrace());
+                           "Please verify authentication properties are provided correctly");
       throw collector.getOrThrowException();
     }
     return oAuthInfo;

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/batch/SalesforceSourceConfig.java
@@ -185,7 +185,6 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
         queryDescriptor = SalesforceQueryParser.getObjectDescriptorFromQuery(query);
       } catch (SOQLParsingException e) {
         collector.addFailure(String.format("Invalid SOQL query '%s' : %s", query, e.getMessage()), null)
-          .withStacktrace(e.getStackTrace())
           .withConfigProperty(SalesforceSourceConstants.PROPERTY_QUERY);
         throw collector.getOrThrowException();
       }
@@ -255,8 +254,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
       String errorMessage = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       collector.addFailure(
           String.format("Cannot establish connection to Salesforce to describe SObject: '%s' with error %s",
-                        sObjectName, errorMessage), null)
-        .withStacktrace(e.getStackTrace());
+                        sObjectName, errorMessage), null);
     }
   }
 
@@ -353,7 +351,7 @@ public class SalesforceSourceConfig extends SalesforceBaseSourceConfig {
     } catch (ConnectionException e) {
       String message = SalesforceConnectionUtil.getSalesforceErrorMessageFromException(e);
       collector.addFailure(String.format("There was issue communicating with Salesforce due to error: %s", message),
-                           null).withStacktrace(e.getStackTrace());
+                           null);
       throw collector.getOrThrowException();
     }
   }


### PR DESCRIPTION
During configuration validation in `SalesforceSourceConfig` and `SalesforceConnectionUtil`, attaching a Java exception stack trace (`.withStacktrace()`) to validation failures caused the hosting runtime (Connectors Service) to classify user configuration errors as internal system faults. 

Removing `.withStacktrace()` consistently across these validation call sites ensures the runtime correctly treats configuration failures as standard user errors, successfully propagating exact Salesforce error messages and error IDs to the client.

This stack trace was exposing a lot of user information which is not required to debug or get the root cause of the issue.