### PR TITLE
Upgrade org.eclipse.jetty to 12.1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jetty.version>12.1.10</jetty.version>
     <powermock.version>2.0.2</powermock.version>
     <failsafe.version>3.3.2</failsafe.version>
   </properties>
@@ -99,7 +100,17 @@
       <dependency>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-http</artifactId>
-          <version>9.4.52.v20230823</version>
+          <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-client</artifactId>
+          <version>${jetty.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+          <version>${jetty.version}</version>
       </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -270,6 +281,22 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-http</artifactId>
             </exclusion>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util-ajax</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+            </exclusion>
         </exclusions>
     </dependency>
     <dependency>
@@ -376,6 +403,14 @@
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty.orbit</groupId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
       <scope>test</scope>

--- a/src/main/java/io/cdap/plugin/salesforce/SalesforceQueryUtil.java
+++ b/src/main/java/io/cdap/plugin/salesforce/SalesforceQueryUtil.java
@@ -21,12 +21,11 @@ import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.parser.SalesforceQueryParser;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
+import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -152,8 +151,7 @@ public class SalesforceQueryUtil {
         SalesforceConstants.API_VERSION,
         URLEncoder.encode(query, "UTF-8"));
 
-    SslContextFactory sslContextFactory = new SslContextFactory();
-    HttpClient httpClient = new HttpClient(sslContextFactory);
+    HttpClient httpClient = new HttpClient();
     httpClient.setConnectTimeout(credentials.getConnectTimeout());
     if (!Strings.isNullOrEmpty(credentials.getProxyUrl())) {
       Authenticator.setProxy(credentials, httpClient);
@@ -163,12 +161,9 @@ public class SalesforceQueryUtil {
       httpClient.start();
       Request request = httpClient.newRequest(explainUrl)
           .method(HttpMethod.GET)
-          .header(
-              HttpHeader.AUTHORIZATION,
-              "Bearer " + oAuthInfo.getAccessToken())
-          .header(
-              HttpHeader.CONTENT_TYPE,
-              "application/json");
+          .headers(headers -> headers
+              .put(HttpHeader.AUTHORIZATION, "Bearer " + oAuthInfo.getAccessToken())
+              .put(HttpHeader.CONTENT_TYPE, "application/json"));
       ContentResponse response = request.send();
       String responseContent = response.getContentAsString();
       if (response.getStatus() != HttpURLConnection.HTTP_OK) {

--- a/src/main/java/io/cdap/plugin/salesforce/authenticator/Authenticator.java
+++ b/src/main/java/io/cdap/plugin/salesforce/authenticator/Authenticator.java
@@ -25,8 +25,7 @@ import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.ProxyConfiguration;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.client.Request;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -89,8 +88,7 @@ public class Authenticator {
       throw new IllegalArgumentException("Grant type cannot be null for OAuth flow to fetch access token.");
     }
 
-    SslContextFactory sslContextFactory = new SslContextFactory();
-    HttpClient httpClient = new HttpClient(sslContextFactory);
+    HttpClient httpClient = new HttpClient();
     httpClient.setConnectTimeout(credentials.getConnectTimeout());
     if (!Strings.isNullOrEmpty(credentials.getProxyUrl())) {
       setProxy(credentials, httpClient);

--- a/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforcePushTopicListener.java
+++ b/src/main/java/io/cdap/plugin/salesforce/plugin/source/streaming/SalesforcePushTopicListener.java
@@ -32,8 +32,7 @@ import org.cometd.client.transport.LongPollingTransport;
 import org.cometd.common.JSONContext;
 import org.cometd.common.JacksonJSONContextClient;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.Request;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.client.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,10 +128,8 @@ public class SalesforcePushTopicListener {
   private BayeuxClient getClient(AuthenticatorCredentials credentials) throws Exception {
     OAuthInfo oAuthInfo = Authenticator.getOAuthInfo(credentials);
 
-    SslContextFactory sslContextFactory = new SslContextFactory();
-
     // Set up a Jetty HTTP client to use with CometD
-    HttpClient httpClient = new HttpClient(sslContextFactory);
+    HttpClient httpClient = new HttpClient();
     httpClient.setConnectTimeout(CONNECTION_TIMEOUT_MS);
     if (!Strings.isNullOrEmpty(credentials.getProxyUrl())) {
       Authenticator.setProxy(credentials, httpClient);
@@ -146,15 +143,15 @@ public class SalesforcePushTopicListener {
     Map<String, Object> transportOptions = new HashMap<>();
     transportOptions.put(ClientTransport.JSON_CONTEXT_OPTION, jsonContext);
 
-    // Adds the OAuth header in LongPollingTransport
-    LongPollingTransport transport = new LongPollingTransport(
-      transportOptions, httpClient) {
+    // Adds the OAuth header for all CometD requests
+    httpClient.getRequestListeners().addListener(new Request.Listener() {
       @Override
-      protected void customize(Request exchange) {
-        super.customize(exchange);
-        exchange.header("Authorization", "OAuth " + oAuthInfo.getAccessToken());
+      public void onBegin(Request request) {
+        request.headers(headers -> headers.put("Authorization", "OAuth " + oAuthInfo.getAccessToken()));
       }
-    };
+    });
+
+    LongPollingTransport transport = new LongPollingTransport(transportOptions, httpClient);
 
     // Now set up the Bayeux client itself
     return new BayeuxClient(oAuthInfo.getInstanceURL() + DEFAULT_PUSH_ENDPOINT, transport);

--- a/src/test/java/io/cdap/plugin/salesforce/SalesforceQueryUtilTest.java
+++ b/src/test/java/io/cdap/plugin/salesforce/SalesforceQueryUtilTest.java
@@ -20,12 +20,11 @@ import io.cdap.plugin.salesforce.authenticator.Authenticator;
 import io.cdap.plugin.salesforce.authenticator.AuthenticatorCredentials;
 import io.cdap.plugin.salesforce.plugin.OAuthInfo;
 import io.cdap.plugin.salesforce.plugin.source.batch.util.SalesforceSplitUtil;
+import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.api.ContentResponse;
-import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -296,13 +295,12 @@ public class SalesforceQueryUtilTest {
     PowerMockito.mockStatic(Authenticator.class);
     PowerMockito.when(Authenticator.getOAuthInfo(credentials)).thenReturn(oAuthInfo);
     HttpClient httpClient = PowerMockito.mock(HttpClient.class);
-    PowerMockito.whenNew(HttpClient.class).withArguments(Mockito.any(SslContextFactory.class))
+    PowerMockito.whenNew(HttpClient.class).withNoArguments()
         .thenReturn(httpClient);
     Request request = Mockito.mock(Request.class);
     Mockito.when(httpClient.newRequest(Mockito.anyString())).thenReturn(request);
     Mockito.when(request.method(Mockito.any(HttpMethod.class))).thenReturn(request);
-    Mockito.when(request.header(Mockito.any(HttpHeader.class), Mockito.anyString()))
-        .thenReturn(request);
+    Mockito.when(request.headers(Mockito.any())).thenReturn(request);
     ContentResponse response = Mockito.mock(ContentResponse.class);
     Mockito.when(request.send()).thenReturn(response);
     Mockito.when(response.getStatus()).thenReturn(HttpURLConnection.HTTP_OK);


### PR DESCRIPTION
### Summary
Upgrades `org.eclipse.jetty` dependencies from `9.4.x` to `12.1.10` in `pom.xml`, excludes outdated transitive Jetty dependencies, and updates codebase to adhere to Jetty 12 API changes.

### Key Changes
1. **Dependency Management & Upgrades (`pom.xml`):**
   - Added `<jetty.version>12.1.10</jetty.version>` to `<properties>`.
   - Updated `jetty-http` and explicitly added `jetty-client` and `jetty-util` dependencies with `${jetty.version}`.
   - Excluded older transitive `9.4.12.v20180830` Jetty artifacts from `cometd-java-client`.
   - Excluded legacy Jetty 8 / Orbit artifacts from `hydrator-test`.

2. **Jetty 12 API Migrations:**
   - **`Authenticator.java` & `SalesforceQueryUtil.java`:**
     - Updated imports from `org.eclipse.jetty.client.api.*` to `org.eclipse.jetty.client.*`.
     - Replaced `new HttpClient(SslContextFactory)` with default `new HttpClient()`.
     - Updated fluent header calls to use `Request.headers(...)`.
   - **`SalesforcePushTopicListener.java`:**
     - Registered OAuth header customization using `httpClient.getRequestListeners().addListener(...)` with `Request.Listener` instead of overriding deprecated `LongPollingTransport.customize(Request)`.
   - **`SalesforceQueryUtilTest.java`:**
     - Updated Mockito / PowerMock expectations to match Jetty 12 `HttpClient` initialization and headers.

### Verification
- Verified dependency tree via `mvn dependency:tree -Dincludes=org.eclipse.jetty*` to ensure no legacy 9.4.x artifacts remain in compile scope.
- Verified compilation via `mvn compile` (BUILD SUCCESS).
